### PR TITLE
chore: add config file merging, wildcard anonymization, and secure file output

### DIFF
--- a/docs/user-guide/advanced-usage.md
+++ b/docs/user-guide/advanced-usage.md
@@ -67,7 +67,28 @@ dbslice extract \
   --out-file user_custom_redact.sql
 ```
 
-You can also define custom patterns and redact lists in your config file. See [Configuration](configuration.md) for the `anonymization` section.
+You can also define explicit redact field mappings in your config file (`anonymization.fields`).  
+You can also define wildcard anonymization rules in config via `anonymization.patterns`
+and wildcard NULL-forcing rules via `anonymization.security_null_fields`.
+
+Example:
+
+```yaml
+anonymization:
+  enabled: true
+  fields:
+    users.email: email                # exact field provider
+  patterns:
+    users.*_name: name                # wildcard field provider
+    "*.phone*": phone_number
+  security_null_fields:
+    - users.password*                 # force NULL
+    - "*.api_key"
+```
+
+Rule precedence is: exact `fields` > wildcard `patterns` > built-in pattern mapping.
+For wildcard conflicts, the most specific rule wins (ties use first-defined order).
+Foreign-key columns are never anonymized or nulled.
 
 ### Deterministic Anonymization
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -80,6 +80,7 @@ dbslice extract [OPTIONS] DATABASE_URL
 |--------|------|---------|-------------|
 | `--output`, `-o` | TEXT | `sql` | Output format: `sql`, `json`, or `csv` |
 | `--out-file`, `-f` | PATH | - | Write to file instead of stdout |
+| `--output-file-mode` | TEXT | `600` | Output file permissions (octal, e.g. `600`, `640`) |
 | `--json-mode` | TEXT | `auto` | JSON mode: `auto`, `single`, or `per-table` |
 | `--json-pretty` / `--json-compact` | FLAG | Pretty | Enable/disable JSON pretty-printing |
 
@@ -87,7 +88,7 @@ dbslice extract [OPTIONS] DATABASE_URL
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--anonymize`, `-a` | FLAG | `False` | Enable automatic anonymization of sensitive fields |
+| `--anonymize` / `--no-anonymize`, `-a` | FLAG | Disabled | Enable/disable automatic anonymization of sensitive fields |
 | `--redact`, `-r` | TEXT | - | Additional fields to redact (repeatable, format: `table.column`) |
 
 ##### Validation Options
@@ -95,14 +96,14 @@ dbslice extract [OPTIONS] DATABASE_URL
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--validate` / `--no-validate` | FLAG | Enabled | Validate extraction for referential integrity |
-| `--fail-on-validation-error` | FLAG | `False` | Stop execution if validation finds issues |
+| `--fail-on-validation-error` / `--no-fail-on-validation-error` | FLAG | Disabled | Stop execution if validation finds issues |
 
 ##### Performance Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--profile` | FLAG | `False` | Enable query profiling and show statistics |
-| `--stream` | FLAG | `False` | Force streaming mode (requires `--out-file`) |
+| `--profile` / `--no-profile` | FLAG | Disabled | Enable query profiling and show statistics |
+| `--stream` / `--no-stream` | FLAG | Disabled | Force streaming mode (requires `--out-file`) |
 | `--stream-threshold` | INTEGER | `50000` | Auto-enable streaming above this row count |
 | `--stream-chunk-size` | INTEGER | `1000` | Rows per chunk in streaming mode |
 
@@ -410,7 +411,7 @@ anonymization:
 output:
   format: sql
   include_transaction: true
-  include_drop_tables: false
+  include_truncate: false
 ```
 
 ---

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -65,7 +65,7 @@ dbslice init postgresql://localhost/mydb --no-detect-sensitive
 The configuration file uses YAML format with the following top-level structure:
 
 ```yaml
-version: "1.0"           # Config file format version
+version: "1.0"           # Optional config version tag (informational)
 database:                # Database connection settings
 extraction:              # Extraction behavior settings
 anonymization:           # Anonymization configuration
@@ -81,10 +81,10 @@ performance:             # Performance tuning (optional)
 ### version
 
 **Type:** String
-**Required:** Yes
-**Default:** `"1.0"`
+**Required:** No
+**Default:** unset
 
-Specifies the configuration file format version. Currently only `"1.0"` is supported.
+Optional schema/version tag for your own tracking. dbslice currently treats this as informational metadata.
 
 ```yaml
 version: "1.0"
@@ -102,7 +102,7 @@ Database connection configuration.
 database:
   url: string              # Database connection URL (required)
   schema: string           # Schema name (optional, default: "public" for PostgreSQL)
-  options: object          # Additional connection options (optional)
+  options: object          # Optional URL query options (key/value)
 ```
 
 #### Fields
@@ -111,7 +111,7 @@ database:
 |-------|------|----------|---------|-------------|
 | `url` | String | Yes | - | Database connection URL |
 | `schema` | String | No | `"public"` | Schema name for PostgreSQL |
-| `options` | Object | No | `{}` | Additional driver-specific options |
+| `options` | Object | No | `{}` | Extra connection options merged into URL query params |
 
 #### Examples
 
@@ -125,11 +125,11 @@ database:
   url: postgresql://user:pass@localhost:5432/mydb
   schema: public
 
-# With connection options
+# Add query options via config
 database:
-  url: postgresql://user:pass@localhost:5432/mydb
+  url: postgresql://user:pass@localhost:5432/mydb?sslmode=disable
   options:
-    connect_timeout: 10
+    sslmode: require
     application_name: dbslice
 
 # Environment variable (recommended for security)
@@ -140,6 +140,10 @@ database:
 database:
   url: ${DATABASE_URL_FILE}
 ```
+
+`database.options` precedence:
+- Applied only when URL comes from config (`database.url`).
+- If CLI provides database URL, config `database.options` are ignored.
 
 ---
 
@@ -156,6 +160,7 @@ extraction:
   exclude_tables: list[string]     # Tables to exclude
   validate: boolean                # Enable validation
   fail_on_validation_error: boolean  # Stop on validation errors
+  max_rows_per_table: integer      # Optional global row soft-cap
 ```
 
 #### Fields
@@ -167,6 +172,13 @@ extraction:
 | `exclude_tables` | List[String] | No | `[]` | Tables to exclude from extraction |
 | `validate` | Boolean | No | `true` | Validate extraction for referential integrity |
 | `fail_on_validation_error` | Boolean | No | `false` | Stop execution if validation finds issues |
+| `max_rows_per_table` | Integer | No | unlimited | Global per-table soft-cap with integrity closure |
+
+`max_rows_per_table` is deterministic and integrity-first:
+- dbslice first caps each table deterministically by primary key sort.
+- It then adds required parent rows so FK integrity is preserved.
+- Parent closure may exceed the configured cap.
+- If any row limit is configured, streaming mode is disabled automatically.
 
 #### Examples
 
@@ -212,9 +224,9 @@ Anonymization and data redaction configuration.
 anonymization:
   enabled: boolean              # Enable anonymization
   seed: string                  # Deterministic seed
-  fields: object                # Field-specific anonymization
-  patterns: object              # Custom pattern matching (optional)
-  security_null_fields: list    # Fields to set to NULL (optional)
+  fields: object                # Exact table.column -> provider
+  patterns: object              # Wildcard table.column glob -> provider
+  security_null_fields: list    # Wildcard table.column globs to force NULL
 ```
 
 #### Fields
@@ -223,9 +235,17 @@ anonymization:
 |-------|------|----------|---------|-------------|
 | `enabled` | Boolean | No | `false` | Enable automatic anonymization |
 | `seed` | String | No | Generated | Deterministic seed for consistent anonymization |
-| `fields` | Object | No | `{}` | Map of `table.column` to Faker method |
-| `patterns` | Object | No | Built-in | Custom pattern matching rules |
-| `security_null_fields` | List[String] | No | Built-in | Fields to set to NULL (passwords, tokens) |
+| `fields` | Object | No | `{}` | Exact map of `table.column` to Faker method |
+| `patterns` | Object | No | `{}` | Wildcard map of `table.column` glob to Faker method |
+| `security_null_fields` | List[String] | No | `[]` | Wildcard `table.column` globs to force `NULL` |
+
+Notes:
+- `fields` keys must be exact `table.column` entries (no wildcards).
+- `patterns` and `security_null_fields` use shell-style globs (`*`, `?`) on `table.column`.
+- Provider names are validated at config-load time; invalid Faker providers fail fast.
+- Rule precedence: exact `fields` > wildcard `patterns` > built-in pattern matching.
+- If multiple wildcard `patterns` match, the most specific wins (ties use first-defined order).
+- Foreign-key columns are never anonymized or nulled.
 
 #### Field Anonymization Methods
 
@@ -274,6 +294,16 @@ anonymization:
     payments.card_number: credit_card_number
     logs.ip_address: ipv4
 
+# Wildcard anonymization + forced NULL rules
+anonymization:
+  enabled: true
+  patterns:
+    users.*_name: name
+    "*.phone*": phone_number
+  security_null_fields:
+    - users.password*
+    - "*.api_key"
+
 # Complete anonymization config
 anonymization:
   enabled: true
@@ -293,7 +323,7 @@ anonymization:
 
     # Financial data
     payments.card_number: credit_card_number
-    payments.routing_number: routing_number
+    payments.routing_number: aba
     payments.account_number: bban
 
     # Contact information
@@ -323,8 +353,9 @@ Output format and generation configuration.
 output:
   format: string                   # Output format (sql/json/csv)
   include_transaction: boolean     # Wrap in BEGIN/COMMIT
-  include_drop_tables: boolean     # Include DROP TABLE statements
+  include_truncate: boolean        # Include TRUNCATE TABLE statements
   disable_fk_checks: boolean       # Disable FK checks during import
+  file_mode: string                # Output file permissions (octal, e.g. "600")
   json_mode: string                # JSON mode (single/per-table)
   json_pretty: boolean             # Pretty-print JSON
 ```
@@ -335,8 +366,9 @@ output:
 |-------|------|----------|---------|-------------|
 | `format` | String | No | `"sql"` | Output format: `sql`, `json`, or `csv` |
 | `include_transaction` | Boolean | No | `true` | Wrap SQL in BEGIN/COMMIT |
-| `include_drop_tables` | Boolean | No | `false` | Include DROP TABLE statements |
+| `include_truncate` | Boolean | No | `false` | Include `TRUNCATE TABLE ... CASCADE` before inserts |
 | `disable_fk_checks` | Boolean | No | `false` | Disable FK checks during import |
+| `file_mode` | String/Octal | No | `"600"` | File permissions for generated outputs |
 | `json_mode` | String | No | `"single"` | JSON mode: `single` or `per-table` |
 | `json_pretty` | Boolean | No | `true` | Pretty-print JSON output |
 
@@ -351,15 +383,19 @@ output:
 output:
   format: sql
   include_transaction: true
-  include_drop_tables: false
+  include_truncate: false
 
 # SQL for test fixtures (destructive)
 output:
   format: sql
   include_transaction: true
-  include_drop_tables: true  # Drops tables before inserting
+  include_truncate: true     # Truncates tables before inserting
   disable_fk_checks: true    # Disables FK checks during import
+```
 
+`include_drop_tables` is still accepted as a backward-compatible alias for `include_truncate`, but is deprecated.
+
+```yaml
 # JSON output (single file)
 output:
   format: json
@@ -390,10 +426,12 @@ Per-table configuration (optional advanced feature).
 ```yaml
 tables:
   table_name:
-    depth: integer               # Override default depth for this table
-    direction: string            # Override direction for this table
-    exclude: boolean             # Exclude this table
-    anonymize_fields: object     # Table-specific anonymization
+    skip: boolean                # Skip table entirely
+    depth: integer               # Per-table DOWN depth override
+    direction: string            # Per-table direction override: up/down/both
+    max_rows: integer            # Per-table row soft-cap (overrides global)
+    anonymize_fields: object     # Deprecated alias: column -> faker provider
+    exclude: boolean             # Deprecated alias for skip
 ```
 
 #### Examples
@@ -401,44 +439,24 @@ tables:
 ```yaml
 # Per-table overrides
 tables:
-  # Deep traversal for critical table
-  orders:
-    depth: 10
-    direction: both
-
-  # Shallow traversal for large table
+  sessions:
+    skip: true
   audit_logs:
-    depth: 1
-    direction: down
+    skip: true
 
-  # Exclude table entirely
-  temp_data:
-    exclude: true
-
-  # Table-specific anonymization
-  users:
-    anonymize_fields:
-      ssn: ssn
-      passport: passport_number
-      tax_id: ssn
-
-# Complete table configuration
-tables:
   orders:
-    depth: 5
-    direction: both
-    anonymize_fields:
-      customer_note: text
-
-  products:
     depth: 2
     direction: up
 
-  sessions:
-    exclude: true
+  users:
+    max_rows: 100
+    anonymize_fields:
+      phone: phone_number
 
-  audit_logs:
-    exclude: true
+Legacy aliases:
+- `tables.<name>.exclude` is accepted as deprecated alias of `skip`.
+- `tables.<name>.anonymize_fields` is accepted as deprecated alias; prefer `anonymization.fields`.
+- If both `anonymization.fields` and `tables.<name>.anonymize_fields` set the same `table.column`, `anonymization.fields` wins.
 ```
 
 ---
@@ -452,11 +470,11 @@ Performance tuning configuration (optional).
 ```yaml
 performance:
   profile: boolean                    # Enable query profiling
+  batch_size: integer                 # Adapter query batch size
   streaming:
     enabled: boolean                  # Force streaming mode
     threshold: integer                # Auto-enable threshold (rows)
     chunk_size: integer               # Rows per chunk
-  batch_size: integer                 # Database batch size
 ```
 
 #### Fields
@@ -464,10 +482,10 @@ performance:
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `profile` | Boolean | No | `false` | Enable query profiling |
+| `batch_size` | Integer | No | adapter default | Query parameter batch size for PostgreSQL adapter |
 | `streaming.enabled` | Boolean | No | `false` | Force streaming mode |
 | `streaming.threshold` | Integer | No | `50000` | Auto-enable streaming above this row count |
 | `streaming.chunk_size` | Integer | No | `1000` | Rows per chunk in streaming mode |
-| `batch_size` | Integer | No | `1000` | Database batch size for bulk operations |
 
 #### Examples
 
@@ -486,11 +504,11 @@ performance:
 # Aggressive performance tuning
 performance:
   profile: true
+  batch_size: 2000
   streaming:
     enabled: false
     threshold: 50000
     chunk_size: 2000
-  batch_size: 2000           # Larger batches for faster queries
 
 # Memory-constrained environment
 performance:
@@ -498,7 +516,6 @@ performance:
     enabled: true            # Always stream
     threshold: 10000         # Low threshold
     chunk_size: 500          # Small chunks
-  batch_size: 500
 ```
 
 ---
@@ -512,8 +529,8 @@ Command-line arguments take precedence over configuration file settings. This al
 ### Override Rules
 
 1. **CLI always wins**: CLI arguments override config file settings
-2. **Merge behavior**: Some options (like seeds, exclude tables) are merged
-3. **Complete replacement**: Other options (like depth, direction) are replaced
+2. **Merge behavior**: Some options (like anonymization field mappings + CLI `--redact`) are merged
+3. **Complete replacement**: Others (like depth, direction, exclude tables) are replaced
 
 ### Override Examples
 
@@ -543,9 +560,9 @@ dbslice extract --config dbslice.yaml --seed "orders.id=1" --depth 5
 dbslice extract --config dbslice.yaml --seed "orders.id=1" --direction up
 # Result: direction=up (CLI wins)
 
-# Add excluded tables (merged)
+# Override excluded tables
 dbslice extract --config dbslice.yaml --seed "orders.id=1" --exclude temp_data
-# Result: exclude_tables = [audit_logs, sessions, temp_data] (merged)
+# Result: exclude_tables = [temp_data] (CLI replacement)
 
 # Disable anonymization
 dbslice extract --config dbslice.yaml --seed "orders.id=1" --no-anonymize
@@ -565,11 +582,7 @@ Configuration files are validated when loaded. Common validation errors:
 ### Schema Validation
 
 ```yaml
-# ❌ Invalid: Missing version
-database:
-  url: postgresql://localhost/mydb
-
-# ✅ Valid: Version specified
+# ✅ Valid: version is optional
 version: "1.0"
 database:
   url: postgresql://localhost/mydb
@@ -660,7 +673,7 @@ anonymization:
 output:
   format: sql
   include_transaction: true
-  include_drop_tables: false
+  include_truncate: false
 
 performance:
   profile: false
@@ -710,7 +723,7 @@ anonymization:
 
     # Financial data
     payments.card_number: credit_card_number
-    payments.routing_number: routing_number
+    payments.routing_number: aba
     payments.cvv: random_int
 
     # Contact info
@@ -721,7 +734,7 @@ anonymization:
 output:
   format: sql
   include_transaction: true
-  include_drop_tables: false
+  include_truncate: false
 
 performance:
   profile: true
@@ -769,7 +782,7 @@ anonymization:
 output:
   format: sql
   include_transaction: true
-  include_drop_tables: true      # Destructive - for test DB
+  include_truncate: true      # Destructive - for test DB
   disable_fk_checks: false        # Keep FK validation
 
 performance:
@@ -867,7 +880,7 @@ anonymization:
 output:
   format: sql
   include_transaction: true
-  include_drop_tables: false
+  include_truncate: false
 
 performance:
   profile: true
@@ -875,7 +888,6 @@ performance:
     enabled: true           # Always stream
     threshold: 10000        # Low threshold
     chunk_size: 1000
-  batch_size: 1000
 ```
 
 **Usage:**

--- a/src/dbslice/__init__.py
+++ b/src/dbslice/__init__.py
@@ -5,5 +5,12 @@ A CLI tool for extracting database subsets that maintain referential integrity,
 useful for local development, debugging, and creating test fixtures.
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("dbslice")
+except PackageNotFoundError:
+    # Fallback for local source execution without installed metadata.
+    __version__ = "0.2.0"
+
 __all__ = ["__version__"]

--- a/src/dbslice/adapters/postgresql.py
+++ b/src/dbslice/adapters/postgresql.py
@@ -98,6 +98,12 @@ class PostgreSQLAdapter(DatabaseAdapter):
             edges = self._fetch_foreign_keys(schema)
             logger.debug("Foreign keys fetched", count=len(edges))
 
+            # Keep per-table FK lists in sync with graph edges.
+            for fk in edges:
+                table = tables.get(fk.source_table)
+                if table is not None:
+                    table.foreign_keys.append(fk)
+
             self._schema_cache = SchemaGraph(tables=tables, edges=edges)
             logger.info(
                 "Schema introspection complete",
@@ -336,15 +342,10 @@ class PostgreSQLAdapter(DatabaseAdapter):
         if not pk_values:
             return
 
-        params_per_row = len(pk_columns)
-        effective_batch_size = self.batch_size // max(params_per_row, 1)
-
         pk_values_list = list(pk_values)
 
         try:
-            for batch_start in range(0, len(pk_values_list), effective_batch_size):
-                batch_end = min(batch_start + effective_batch_size, len(pk_values_list))
-                batch_pks = pk_values_list[batch_start:batch_end]
+            for _, batch_pks in self._iter_pk_batches(pk_values_list, len(pk_columns)):
 
                 if len(pk_columns) == 1:
                     col = pk_columns[0]
@@ -411,15 +412,10 @@ class PostgreSQLAdapter(DatabaseAdapter):
         if not pk_values:
             return
 
-        params_per_row = len(pk_columns)
-        effective_batch_size = self.batch_size // max(params_per_row, 1)
-
         pk_values_list = list(pk_values)
 
         try:
-            for batch_start in range(0, len(pk_values_list), effective_batch_size):
-                batch_end = min(batch_start + effective_batch_size, len(pk_values_list))
-                batch_pks = pk_values_list[batch_start:batch_end]
+            for batch_start, batch_pks in self._iter_pk_batches(pk_values_list, len(pk_columns)):
 
                 if len(pk_columns) == 1:
                     col = pk_columns[0]
@@ -480,15 +476,12 @@ class PostgreSQLAdapter(DatabaseAdapter):
         pk_cols = source_table.primary_key
         fk_cols = fk.source_columns
 
-        params_per_row = len(pk_cols)
-        effective_batch_size = self.batch_size // max(params_per_row, 1)
-
         result: set[tuple[Any, ...]] = set()
         pk_values_list = list(source_pk_values)
 
-        for batch_start in range(0, len(pk_values_list), effective_batch_size):
-            batch_end = min(batch_start + effective_batch_size, len(pk_values_list))
-            batch_pks = pk_values_list[batch_start:batch_end]
+        effective_batch_size = self._effective_batch_size(len(pk_cols))
+
+        for _, batch_pks in self._iter_pk_batches(pk_values_list, len(pk_cols)):
 
             if len(pk_cols) == 1:
                 pk_col = pk_cols[0]
@@ -574,17 +567,13 @@ class PostgreSQLAdapter(DatabaseAdapter):
             )
             return set()
 
-        params_per_row = len(fk_cols)
-        effective_batch_size = self.batch_size // max(params_per_row, 1)
-
         result: set[tuple[Any, ...]] = set()
         pk_values_list = list(target_pk_values)
+        effective_batch_size = self._effective_batch_size(len(fk_cols))
 
         pk_select = ", ".join(f'"{c}"' for c in pk_cols)
 
-        for batch_start in range(0, len(pk_values_list), effective_batch_size):
-            batch_end = min(batch_start + effective_batch_size, len(pk_values_list))
-            batch_pks = pk_values_list[batch_start:batch_end]
+        for _, batch_pks in self._iter_pk_batches(pk_values_list, len(fk_cols)):
 
             if len(fk_cols) == 1:
                 fk_col = fk_cols[0]
@@ -690,6 +679,21 @@ class PostgreSQLAdapter(DatabaseAdapter):
             raise ExtractionError(
                 f"Failed to fetch all PKs from passthrough table '{table}': {e}", table=table
             ) from e
+
+    def _effective_batch_size(self, params_per_row: int) -> int:
+        """Calculate effective batch size accounting for params per row."""
+        return max(1, self.batch_size // max(params_per_row, 1))
+
+    def _iter_pk_batches(
+        self,
+        pk_values_list: list[tuple[Any, ...]],
+        params_per_row: int,
+    ) -> Iterator[tuple[int, list[tuple[Any, ...]]]]:
+        """Yield (start_index, batch_values) pairs for PK batching."""
+        effective_batch_size = self._effective_batch_size(params_per_row)
+        for batch_start in range(0, len(pk_values_list), effective_batch_size):
+            batch_end = min(batch_start + effective_batch_size, len(pk_values_list))
+            yield batch_start, pk_values_list[batch_start:batch_end]
 
     def get_table_pk_columns(self, table: str) -> tuple[str, ...]:
         """Get primary key column names for a table."""

--- a/src/dbslice/cli.py
+++ b/src/dbslice/cli.py
@@ -7,7 +7,12 @@ from rich.status import Status
 
 from dbslice import __version__
 from dbslice.config import ExtractConfig, OutputFormat, SeedSpec, TraversalDirection
-from dbslice.constants import DEFAULT_TRAVERSAL_DEPTH
+from dbslice.constants import (
+    DEFAULT_OUTPUT_FILE_MODE,
+    DEFAULT_STREAMING_CHUNK_SIZE,
+    DEFAULT_STREAMING_THRESHOLD,
+    DEFAULT_TRAVERSAL_DEPTH,
+)
 from dbslice.core.engine import ExtractionEngine
 from dbslice.exceptions import (
     CircularReferenceError,
@@ -22,6 +27,7 @@ from dbslice.input_validators import (
     validate_database_url,
     validate_depth,
     validate_exclude_tables,
+    validate_output_file_mode,
     validate_output_file_path,
     validate_redact_fields,
 )
@@ -30,6 +36,7 @@ from dbslice.output.csv_out import CSVGenerator
 from dbslice.output.json_out import JSONGenerator
 from dbslice.output.sql import SQLGenerator
 from dbslice.utils.connection import parse_database_url
+from dbslice.utils.fileio import write_text_file_secure
 
 logger = get_logger(__name__)
 
@@ -175,6 +182,10 @@ def _build_extract_config(
     validate: bool,
     fail_on_validation_error: bool,
     profile: bool,
+    stream: bool,
+    stream_threshold: int,
+    stream_chunk_size: int,
+    output_file_mode: int,
     schema: str | None = None,
 ) -> ExtractConfig:
     """
@@ -197,6 +208,10 @@ def _build_extract_config(
         validate: Enable extraction validation
         fail_on_validation_error: Stop on validation error
         profile: Enable query profiling
+        stream: Force streaming mode
+        stream_threshold: Auto-enable streaming above this row count
+        stream_chunk_size: Streaming fetch chunk size
+        output_file_mode: Permissions mode for output files
 
     Returns:
         Configured ExtractConfig object
@@ -218,6 +233,10 @@ def _build_extract_config(
         validate=validate,
         fail_on_validation_error=fail_on_validation_error,
         profile=profile,
+        stream=stream,
+        streaming_threshold=stream_threshold,
+        streaming_chunk_size=stream_chunk_size,
+        output_file_mode=output_file_mode,
         schema=schema,
     )
 
@@ -368,6 +387,10 @@ def _generate_and_output_sql(
     no_progress: bool,
     console: Console,
     stdout_console: Console,
+    include_transaction: bool,
+    include_truncate: bool,
+    disable_fk_checks: bool,
+    output_file_mode: int,
     db_schema: str | None = None,
 ) -> None:
     """
@@ -386,7 +409,13 @@ def _generate_and_output_sql(
     db_config = parse_database_url(database_url)
 
     # Use schema from extraction (no reconnection needed)
-    generator = SQLGenerator(db_type=db_config.db_type, schema=db_schema)
+    generator = SQLGenerator(
+        db_type=db_config.db_type,
+        include_transaction=include_transaction,
+        include_truncate=include_truncate,
+        disable_fk_checks=disable_fk_checks,
+        schema=db_schema,
+    )
     sql_output = generator.generate(
         result.tables,
         result.insert_order,
@@ -396,7 +425,7 @@ def _generate_and_output_sql(
     )
 
     if out_file:
-        out_file.write_text(sql_output)
+        write_text_file_secure(out_file, sql_output, file_mode=output_file_mode)
         if not no_progress:
             console.print()
             console.print(
@@ -418,6 +447,7 @@ def _generate_and_output_json(
     no_progress: bool,
     console: Console,
     stdout_console: Console,
+    output_file_mode: int,
 ) -> None:
     """
     Generate JSON output and write to file(s) or stdout.
@@ -453,7 +483,9 @@ def _generate_and_output_json(
         if mode == "single":
             assert isinstance(json_output, str)
             out_file.parent.mkdir(parents=True, exist_ok=True)
-            out_file.write_text(json_output, encoding="utf-8")
+            write_text_file_secure(
+                out_file, json_output, file_mode=output_file_mode, encoding="utf-8"
+            )
             if not no_progress:
                 console.print()
                 console.print(
@@ -464,7 +496,9 @@ def _generate_and_output_json(
             out_file.mkdir(parents=True, exist_ok=True)
             for table_name, table_json in json_output.items():
                 table_file = out_file / f"{table_name}.json"
-                table_file.write_text(table_json, encoding="utf-8")
+                write_text_file_secure(
+                    table_file, table_json, file_mode=output_file_mode, encoding="utf-8"
+                )
             if not no_progress:
                 console.print()
                 console.print(
@@ -500,6 +534,7 @@ def _generate_and_output_csv(
     no_progress: bool,
     console: Console,
     stdout_console: Console,
+    output_file_mode: int,
 ) -> None:
     """
     Generate CSV output and write to file(s) or stdout.
@@ -535,7 +570,9 @@ def _generate_and_output_csv(
         if mode == "single":
             assert isinstance(csv_output, str)
             out_file.parent.mkdir(parents=True, exist_ok=True)
-            out_file.write_text(csv_output, encoding="utf-8")
+            write_text_file_secure(
+                out_file, csv_output, file_mode=output_file_mode, encoding="utf-8"
+            )
             if not no_progress:
                 console.print()
                 console.print(
@@ -546,7 +583,9 @@ def _generate_and_output_csv(
             out_file.mkdir(parents=True, exist_ok=True)
             for table_name, table_csv in csv_output.items():
                 table_file = out_file / f"{table_name}.csv"
-                table_file.write_text(table_csv, encoding="utf-8")
+                write_text_file_secure(
+                    table_file, table_csv, file_mode=output_file_mode, encoding="utf-8"
+                )
             if not no_progress:
                 console.print()
                 console.print(
@@ -577,6 +616,7 @@ def _handle_output_format(
     output_format: OutputFormat,
     result,
     schema,
+    extract_config: ExtractConfig,
     database_url: str,
     out_file: Path | None,
     json_mode: str,
@@ -595,6 +635,7 @@ def _handle_output_format(
         output_format: Desired output format (SQL, JSON, or CSV)
         result: Extraction result
         schema: Database schema
+        extract_config: Extraction config with output behavior flags
         database_url: Database connection URL
         out_file: Optional output file path
         json_mode: JSON output mode ("auto", "single", or "per-table")
@@ -617,6 +658,10 @@ def _handle_output_format(
             no_progress,
             console,
             stdout_console,
+            include_transaction=extract_config.include_transaction,
+            include_truncate=extract_config.include_truncate,
+            disable_fk_checks=extract_config.disable_fk_checks,
+            output_file_mode=extract_config.output_file_mode,
             db_schema=db_schema,
         )
     elif output_format == OutputFormat.JSON:
@@ -629,6 +674,7 @@ def _handle_output_format(
             no_progress,
             console,
             stdout_console,
+            output_file_mode=extract_config.output_file_mode,
         )
     elif output_format == OutputFormat.CSV:
         _generate_and_output_csv(
@@ -640,6 +686,7 @@ def _handle_output_format(
             no_progress,
             console,
             stdout_console,
+            output_file_mode=extract_config.output_file_mode,
         )
 
 
@@ -668,28 +715,28 @@ def extract(
         ),
     ] = None,
     depth: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--depth",
             "-d",
             help="Maximum FK traversal depth",
         ),
-    ] = DEFAULT_TRAVERSAL_DEPTH,
+    ] = None,
     direction: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--direction",
             help="Traversal direction: 'up' (parents), 'down' (children), 'both'",
         ),
-    ] = "both",
+    ] = None,
     output: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--output",
             "-o",
             help="Output format: sql, json, csv",
         ),
-    ] = "sql",
+    ] = None,
     out_file: Annotated[
         Path | None,
         typer.Option(
@@ -723,13 +770,13 @@ def extract(
         ),
     ] = False,
     anonymize: Annotated[
-        bool,
+        bool | None,
         typer.Option(
-            "--anonymize",
+            "--anonymize/--no-anonymize",
             "-a",
-            help="Enable automatic anonymization of detected sensitive fields",
+            help="Enable/disable automatic anonymization of detected sensitive fields",
         ),
-    ] = False,
+    ] = None,
     redact: Annotated[
         list[str] | None,
         typer.Option(
@@ -753,75 +800,82 @@ def extract(
         ),
     ] = False,
     json_mode: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--json-mode",
             help="JSON output mode: 'auto' (default), 'single' (one file), 'per-table' (separate files)",
         ),
-    ] = "auto",
+    ] = None,
     json_pretty: Annotated[
-        bool,
+        bool | None,
         typer.Option(
             "--json-pretty/--json-compact",
             help="Enable/disable JSON pretty-printing (default: enabled)",
         ),
-    ] = True,
+    ] = None,
     csv_mode: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--csv-mode",
             help="CSV output mode: 'auto' (default), 'single' (one file), 'per-table' (separate files)",
         ),
-    ] = "auto",
+    ] = None,
     csv_delimiter: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--csv-delimiter",
             help="CSV field delimiter (default: comma)",
         ),
-    ] = ",",
+    ] = None,
     validate: Annotated[
-        bool,
+        bool | None,
         typer.Option(
             "--validate/--no-validate",
             help="Validate extraction for referential integrity (default: enabled)",
         ),
-    ] = True,
+    ] = None,
     fail_on_validation_error: Annotated[
-        bool,
+        bool | None,
         typer.Option(
-            "--fail-on-validation-error",
+            "--fail-on-validation-error/--no-fail-on-validation-error",
             help="Stop execution if validation finds issues (default: disabled, shows warning)",
         ),
-    ] = False,
+    ] = None,
     profile: Annotated[
-        bool,
+        bool | None,
         typer.Option(
-            "--profile",
+            "--profile/--no-profile",
             help="Enable query profiling and show performance statistics",
         ),
-    ] = False,
+    ] = None,
     stream: Annotated[
-        bool,
+        bool | None,
         typer.Option(
-            "--stream",
+            "--stream/--no-stream",
             help="Force streaming mode (write data directly to file without loading into memory)",
         ),
-    ] = False,
+    ] = None,
     stream_threshold: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--stream-threshold",
             help="Auto-enable streaming mode above this row count (default: 50000)",
         ),
-    ] = 50000,
+    ] = None,
     stream_chunk_size: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--stream-chunk-size",
             help="Number of rows to fetch per chunk in streaming mode (default: 1000)",
         ),
-    ] = 1000,
+    ] = None,
+    output_file_mode: Annotated[
+        str | None,
+        typer.Option(
+            "--output-file-mode",
+            help="Permissions for output files (octal, e.g. 600 or 640).",
+        ),
+    ] = None,
     schema: Annotated[
         str | None,
         typer.Option(
@@ -868,6 +922,24 @@ def extract(
     try:
         setup_logging(verbose=verbose, no_progress=no_progress, structured=False)
         logger.debug("CLI command invoked", command="extract", depth=depth, direction=direction)
+        database_url_from_cli = database_url is not None
+
+        effective_depth = depth if depth is not None else DEFAULT_TRAVERSAL_DEPTH
+        effective_direction = direction if direction is not None else "both"
+        effective_output = output if output is not None else "sql"
+        effective_validate = validate if validate is not None else True
+        effective_fail_on_validation_error = (
+            fail_on_validation_error if fail_on_validation_error is not None else False
+        )
+        effective_profile = profile if profile is not None else False
+        effective_stream = stream if stream is not None else False
+        effective_stream_threshold = (
+            stream_threshold if stream_threshold is not None else DEFAULT_STREAMING_THRESHOLD
+        )
+        effective_stream_chunk_size = (
+            stream_chunk_size if stream_chunk_size is not None else DEFAULT_STREAMING_CHUNK_SIZE
+        )
+        effective_output_file_mode = DEFAULT_OUTPUT_FILE_MODE
 
         loaded_config = None
         if config:
@@ -894,25 +966,52 @@ def extract(
 
         assert database_url is not None  # Guaranteed by the check above
 
+        effective_json_mode = json_mode if json_mode is not None else "auto"
+        effective_json_pretty = json_pretty if json_pretty is not None else True
+        effective_csv_mode = csv_mode if csv_mode is not None else "auto"
+        effective_csv_delimiter = csv_delimiter if csv_delimiter is not None else ","
+
+        if loaded_config:
+            if json_mode is None:
+                effective_json_mode = loaded_config.output.json_mode
+            if json_pretty is None:
+                effective_json_pretty = loaded_config.output.json_pretty
+            if csv_mode is None:
+                effective_csv_mode = loaded_config.output.csv_mode
+            if csv_delimiter is None:
+                effective_csv_delimiter = loaded_config.output.csv_delimiter
+
         try:
             validate_database_url(database_url)
-            validate_depth(depth)
+            validate_depth(effective_depth)
             if out_file:
                 validate_output_file_path(out_file)
+            if output_file_mode is not None:
+                effective_output_file_mode = validate_output_file_mode(output_file_mode)
             if exclude:
                 validate_exclude_tables(exclude)
             if passthrough:
                 validate_exclude_tables(passthrough)  # Same validation as exclude
             if redact:
                 validate_redact_fields(redact)
-            if json_mode not in ("auto", "single", "per-table"):
+            if direction is not None and direction.lower() not in {"up", "down", "both"}:
+                raise ValueError("Invalid direction. Use: up, down, both")
+            if output is not None and output.lower() not in {"sql", "json", "csv"}:
+                raise ValueError("Invalid output format. Use: sql, json, csv")
+            if effective_json_mode not in ("auto", "single", "per-table"):
                 raise ValueError(
-                    f"Invalid json_mode: {json_mode}. Must be 'auto', 'single', or 'per-table'"
+                    f"Invalid json_mode: {effective_json_mode}. Must be 'auto', 'single', or 'per-table'"
                 )
-            if csv_mode not in ("auto", "single", "per-table"):
+            if effective_csv_mode not in ("auto", "single", "per-table"):
                 raise ValueError(
-                    f"Invalid csv_mode: {csv_mode}. Must be 'auto', 'single', or 'per-table'"
+                    f"Invalid csv_mode: {effective_csv_mode}. Must be 'auto', 'single', or 'per-table'"
                 )
+            if len(effective_csv_delimiter) != 1:
+                raise ValueError("--csv-delimiter must be a single character")
+            if effective_stream_threshold <= 0:
+                raise ValueError("--stream-threshold must be greater than 0")
+            if effective_stream_chunk_size <= 0:
+                raise ValueError("--stream-chunk-size must be greater than 0")
         except ValidationError as e:
             console.print(f"[red]Validation Error:[/red] {e}")
             raise typer.Exit(1)
@@ -923,35 +1022,20 @@ def extract(
         seed_specs = _parse_and_validate_seeds(seed or [], console)
 
         if loaded_config:
-            direction_enum = TraversalDirection(direction) if direction != "both" else None
-            output_format_enum = OutputFormat(output) if output != "sql" else None
+            direction_enum = (
+                TraversalDirection(effective_direction.lower()) if direction is not None else None
+            )
+            output_format_enum = (
+                OutputFormat(effective_output.lower()) if output is not None else None
+            )
 
             extract_config = loaded_config.to_extract_config(
                 seeds=seed_specs,
-                database_url=database_url,
-                depth=depth if depth != DEFAULT_TRAVERSAL_DEPTH else None,
+                database_url=database_url if database_url_from_cli else None,
+                depth=depth,
                 direction=direction_enum,
                 output_format=output_format_enum,
                 output_file=str(out_file) if out_file else None,
-                exclude=exclude,
-                passthrough=passthrough,
-                anonymize=anonymize if anonymize else None,
-                redact=redact,
-                verbose=verbose,
-                dry_run=dry_run,
-                no_progress=no_progress,
-                schema=schema,
-            )
-            output_format = extract_config.output_format
-        else:
-            direction_enum, output_format = _parse_enum_parameters(direction, output, console)
-            extract_config = _build_extract_config(
-                database_url=database_url,
-                seeds=seed_specs,
-                depth=depth,
-                direction=direction_enum,
-                output_format=output_format,
-                out_file=out_file,
                 exclude=exclude,
                 passthrough=passthrough,
                 anonymize=anonymize,
@@ -962,11 +1046,42 @@ def extract(
                 validate=validate,
                 fail_on_validation_error=fail_on_validation_error,
                 profile=profile,
+                stream=stream,
+                stream_threshold=stream_threshold,
+                stream_chunk_size=stream_chunk_size,
+                output_file_mode=effective_output_file_mode
+                if output_file_mode is not None
+                else None,
                 schema=schema,
             )
-            extract_config.stream = stream
-            extract_config.streaming_threshold = stream_threshold
-            extract_config.streaming_chunk_size = stream_chunk_size
+            output_format = extract_config.output_format
+        else:
+            direction_enum, output_format = _parse_enum_parameters(
+                effective_direction, effective_output, console
+            )
+            extract_config = _build_extract_config(
+                database_url=database_url,
+                seeds=seed_specs,
+                depth=effective_depth,
+                direction=direction_enum,
+                output_format=output_format,
+                out_file=out_file,
+                exclude=exclude,
+                passthrough=passthrough,
+                anonymize=bool(anonymize) if anonymize is not None else False,
+                redact=redact,
+                verbose=verbose,
+                dry_run=dry_run,
+                no_progress=no_progress,
+                validate=effective_validate,
+                fail_on_validation_error=effective_fail_on_validation_error,
+                profile=effective_profile,
+                stream=effective_stream,
+                stream_threshold=effective_stream_threshold,
+                stream_chunk_size=effective_stream_chunk_size,
+                output_file_mode=effective_output_file_mode,
+                schema=schema,
+            )
 
         if verbose and not no_progress:
             _show_extraction_settings(extract_config, console)
@@ -980,12 +1095,13 @@ def extract(
             output_format=output_format,
             result=result,
             schema=schema,
-            database_url=database_url,
+            extract_config=extract_config,
+            database_url=extract_config.database_url,
             out_file=out_file,
-            json_mode=json_mode,
-            json_pretty=json_pretty,
-            csv_mode=csv_mode,
-            csv_delimiter=csv_delimiter,
+            json_mode=effective_json_mode,
+            json_pretty=effective_json_pretty,
+            csv_mode=effective_csv_mode,
+            csv_delimiter=effective_csv_delimiter,
             no_progress=no_progress,
             console=console,
             stdout_console=stdout_console,
@@ -1102,7 +1218,7 @@ def init(
             ExtractionConfig,
             OutputConfig,
         )
-        from dbslice.utils.connection import get_adapter_for_url, parse_database_url
+        from dbslice.utils.connection import get_adapter_for_url
 
         db_config = parse_database_url(database_url)
         with console.status("[bold blue]Connecting to database...[/bold blue]"):
@@ -1143,13 +1259,17 @@ def init(
                 output=OutputConfig(
                     format="sql",
                     include_transaction=True,
-                    include_drop_tables=False,
+                    include_truncate=False,
                 ),
                 tables={},
             )
 
             yaml_content = config.to_yaml(include_comments=True)
-            out_file.write_text(yaml_content)
+            write_text_file_secure(
+                out_file,
+                yaml_content,
+                file_mode=DEFAULT_OUTPUT_FILE_MODE,
+            )
 
             console.print()
             console.print(f"[green]Configuration written to [bold]{out_file}[/bold][/green]")
@@ -1279,7 +1399,7 @@ def inspect(
             raise typer.Exit(1)
 
         from dbslice.adapters.postgresql import PostgreSQLAdapter
-        from dbslice.utils.connection import get_adapter_for_url, parse_database_url
+        from dbslice.utils.connection import get_adapter_for_url
 
         db_config = parse_database_url(database_url)
         with console.status("[bold blue]Connecting to database...[/bold blue]"):

--- a/src/dbslice/config.py
+++ b/src/dbslice/config.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
-from dbslice.constants import DEFAULT_TRAVERSAL_DEPTH
+from dbslice.constants import (
+    DEFAULT_OUTPUT_FILE_MODE,
+    DEFAULT_STREAMING_CHUNK_SIZE,
+    DEFAULT_STREAMING_THRESHOLD,
+    DEFAULT_TRAVERSAL_DEPTH,
+)
 from dbslice.models import VirtualForeignKey
 
 
@@ -287,7 +292,20 @@ class ExtractConfig:
     fail_on_validation_error: bool = False
     profile: bool = False  # Enable query profiling
     stream: bool = False  # Force streaming mode
-    streaming_threshold: int = 50000  # Auto-enable streaming above this row count
-    streaming_chunk_size: int = 1000  # Rows per chunk in streaming mode
+    streaming_threshold: int = DEFAULT_STREAMING_THRESHOLD
+    streaming_chunk_size: int = DEFAULT_STREAMING_CHUNK_SIZE
+    db_batch_size: int | None = None
+    include_transaction: bool = True
+    include_truncate: bool = False
+    disable_fk_checks: bool = False
+    output_file_mode: int = DEFAULT_OUTPUT_FILE_MODE
+    table_depth_overrides: dict[str, int] = field(default_factory=dict)
+    table_direction_overrides: dict[str, TraversalDirection] = field(default_factory=dict)
+    row_limit_global: int | None = None
+    row_limit_per_table: dict[str, int] = field(default_factory=dict)
+    anonymization_seed: str | None = None
+    anonymization_field_providers: dict[str, str] = field(default_factory=dict)
+    anonymization_patterns: dict[str, str] = field(default_factory=dict)
+    security_null_fields: list[str] = field(default_factory=list)
     virtual_foreign_keys: list[VirtualForeignKey] = field(default_factory=list)
     schema: str | None = None  # PostgreSQL schema name (default: public)

--- a/src/dbslice/config_file.py
+++ b/src/dbslice/config_file.py
@@ -1,17 +1,170 @@
+import inspect
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import yaml
 
 from dbslice.config import ExtractConfig, OutputFormat, SeedSpec, TraversalDirection
-from dbslice.constants import DEFAULT_TRAVERSAL_DEPTH
+from dbslice.constants import (
+    DEFAULT_OUTPUT_FILE_MODE,
+    DEFAULT_STREAMING_CHUNK_SIZE,
+    DEFAULT_STREAMING_THRESHOLD,
+    DEFAULT_TRAVERSAL_DEPTH,
+)
 from dbslice.exceptions import DbsliceError
 from dbslice.logging import get_logger
 from dbslice.models import VirtualForeignKey
 
 logger = get_logger(__name__)
+
+_TOP_LEVEL_KEYS = {
+    "version",
+    "database",
+    "extraction",
+    "anonymization",
+    "output",
+    "performance",
+    "tables",
+    "virtual_foreign_keys",
+}
+_DATABASE_KEYS = {"url", "schema", "options"}
+_EXTRACTION_KEYS = {
+    "default_depth",
+    "direction",
+    "exclude_tables",
+    "passthrough_tables",
+    "validate",
+    "fail_on_validation_error",
+    "max_rows_per_table",
+}
+_ANONYMIZATION_KEYS = {
+    "enabled",
+    "seed",
+    "fields",
+    "patterns",
+    "security_null_fields",
+}
+_OUTPUT_KEYS = {
+    "format",
+    "include_transaction",
+    "include_truncate",
+    "include_drop_tables",
+    "disable_fk_checks",
+    "file_mode",
+    "json_mode",
+    "json_pretty",
+    "csv_mode",
+    "csv_delimiter",
+}
+_PERFORMANCE_KEYS = {"profile", "streaming", "batch_size"}
+_STREAMING_KEYS = {"enabled", "threshold", "chunk_size"}
+_TABLE_OVERRIDE_KEYS = {"skip", "max_rows", "depth", "direction", "exclude", "anonymize_fields"}
+_VIRTUAL_FK_KEYS = {
+    "source_table",
+    "source_columns",
+    "target_table",
+    "target_columns",
+    "description",
+    "name",
+    "is_nullable",
+}
+
+
+def _validate_unknown_keys(section_name: str, data: dict[str, Any], allowed: set[str]) -> None:
+    unknown = sorted(set(data.keys()) - allowed)
+    if unknown:
+        raise ValueError(
+            f"Unknown key(s) in '{section_name}': {', '.join(unknown)}. "
+            "Remove unsupported fields or update your config."
+        )
+
+
+def _validate_exact_field_key(key: str, section_name: str) -> None:
+    """Validate exact table.column keys (no wildcards)."""
+    if not isinstance(key, str):
+        raise ValueError(f"{section_name} keys must be strings")
+    if "*" in key or "?" in key:
+        raise ValueError(
+            f"{section_name} key '{key}' must be an exact table.column without wildcards"
+        )
+    parts = key.split(".")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(f"{section_name} key '{key}' must be in table.column format")
+
+
+def _validate_glob_field_pattern(pattern: str, section_name: str) -> None:
+    """Validate wildcard table.column glob patterns."""
+    if not isinstance(pattern, str):
+        raise ValueError(f"{section_name} entries must be strings")
+    parts = pattern.split(".")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(
+            f"{section_name} pattern '{pattern}' must be in table.column format (glob allowed)"
+        )
+
+
+def _validate_faker_provider(provider: str) -> None:
+    """Validate that a Faker provider exists and is callable without required args."""
+    if not isinstance(provider, str) or not provider:
+        raise ValueError("Faker provider name must be a non-empty string")
+
+    try:
+        from faker import Faker
+    except ImportError as e:
+        raise ValueError("Faker is required to validate anonymization providers") from e
+
+    fake = Faker()
+    method = getattr(fake, provider, None)
+    if method is None or not callable(method):
+        raise ValueError(f"Unknown Faker provider '{provider}'")
+
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError):
+        # If we cannot introspect, accept callable as valid.
+        return
+
+    for param in signature.parameters.values():
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+        if param.default is inspect.Parameter.empty:
+            raise ValueError(
+                f"Faker provider '{provider}' requires parameter '{param.name}' and "
+                "cannot be used without arguments"
+            )
+
+
+def _normalize_database_options(raw_options: Any) -> dict[str, str]:
+    """Validate and normalize database options to string values."""
+    if raw_options is None:
+        return {}
+    if not isinstance(raw_options, dict):
+        raise ValueError("'database.options' must be a mapping")
+
+    normalized: dict[str, str] = {}
+    for key, value in raw_options.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError("'database.options' keys must be non-empty strings")
+        if value is None or not isinstance(value, (str, int, float, bool)):
+            raise ValueError(
+                "'database.options' values must be scalar (string, number, or boolean)"
+            )
+        normalized[key] = str(value).lower() if isinstance(value, bool) else str(value)
+    return normalized
+
+
+def _merge_database_url_options(url: str, options: dict[str, str]) -> str:
+    """Merge/override query options into a database URL."""
+    if not options:
+        return url
+    parsed = urlparse(url)
+    existing = parse_qs(parsed.query, keep_blank_values=True)
+    for key, value in options.items():
+        existing[key] = [value]
+    merged_query = urlencode(existing, doseq=True)
+    return urlunparse(parsed._replace(query=merged_query))
 
 
 def _mask_url_password(url: str) -> str:
@@ -30,12 +183,24 @@ def _mask_url_password(url: str) -> str:
     return url
 
 
+def _yaml_quote(value: str) -> str:
+    """Quote a YAML scalar deterministically for safe inline emission."""
+    return yaml.safe_dump(
+        value,
+        default_style='"',
+        default_flow_style=True,
+        allow_unicode=False,
+    ).strip()
+
+
 __all__ = [
     "DbsliceConfig",
     "DatabaseConfig",
     "ExtractionConfig",
     "AnonymizationConfig",
     "OutputConfig",
+    "PerformanceConfig",
+    "StreamingConfig",
     "TableOverride",
     "VirtualForeignKeyConfig",
     "ConfigFileError",
@@ -62,6 +227,9 @@ class DatabaseConfig:
     schema: str | None = None
     """PostgreSQL schema name (default: 'public')."""
 
+    options: dict[str, str] = field(default_factory=dict)
+    """Additional connection options merged into URL query parameters."""
+
 
 @dataclass
 class ExtractionConfig:
@@ -78,6 +246,12 @@ class ExtractionConfig:
 
     passthrough_tables: list[str] = field(default_factory=list)
     """Tables to include in full, regardless of FK relationships (e.g., lookup tables, config tables)."""
+
+    validate: bool = True
+    """Validate extraction for referential integrity."""
+
+    fail_on_validation_error: bool = False
+    """Fail extraction when validation errors are detected."""
 
     max_rows_per_table: int | None = None
     """Global limit on rows per table (None = unlimited)."""
@@ -100,6 +274,20 @@ class AnonymizationConfig:
     Example: {"users.email": "email", "users.phone": "phone_number"}
     """
 
+    patterns: dict[str, str] = field(default_factory=dict)
+    """
+    Wildcard anonymization mappings.
+    Format: {"table_glob.column_glob": "faker_provider"}
+    Example: {"users.*_email": "email", "*.phone*": "phone_number"}
+    """
+
+    security_null_fields: list[str] = field(default_factory=list)
+    """
+    Wildcard field list to force NULL for sensitive values.
+    Format: ["table_glob.column_glob"]
+    Example: ["users.password*", "*.api_key"]
+    """
+
 
 @dataclass
 class OutputConfig:
@@ -111,8 +299,44 @@ class OutputConfig:
     include_transaction: bool = True
     """Wrap SQL output in transaction block."""
 
-    include_drop_tables: bool = False
-    """Include DROP TABLE statements in SQL output."""
+    include_truncate: bool = False
+    """Include TRUNCATE TABLE statements before inserts."""
+
+    disable_fk_checks: bool = False
+    """Disable FK checks while importing generated SQL."""
+
+    file_mode: int = DEFAULT_OUTPUT_FILE_MODE
+    """Permissions mode for output files (octal)."""
+
+    json_mode: str = "auto"
+    """JSON output mode: auto, single, or per-table."""
+
+    json_pretty: bool = True
+    """Enable pretty-printed JSON output."""
+
+    csv_mode: str = "auto"
+    """CSV output mode: auto, single, or per-table."""
+
+    csv_delimiter: str = ","
+    """CSV delimiter character."""
+
+
+@dataclass
+class StreamingConfig:
+    """Streaming performance configuration."""
+
+    enabled: bool = False
+    threshold: int = DEFAULT_STREAMING_THRESHOLD
+    chunk_size: int = DEFAULT_STREAMING_CHUNK_SIZE
+
+
+@dataclass
+class PerformanceConfig:
+    """Performance-related configuration."""
+
+    profile: bool = False
+    streaming: StreamingConfig = field(default_factory=StreamingConfig)
+    batch_size: int | None = None
 
 
 @dataclass
@@ -122,8 +346,17 @@ class TableOverride:
     skip: bool = False
     """Skip this table entirely."""
 
+    depth: int | None = None
+    """Per-table max depth override for downward traversal."""
+
+    direction: str | None = None
+    """Per-table traversal direction override: up, down, or both."""
+
     max_rows: int | None = None
     """Limit rows extracted from this table."""
+
+    anonymize_fields: dict[str, str] = field(default_factory=dict)
+    """Deprecated per-table anonymization mappings (column -> provider)."""
 
 
 @dataclass
@@ -161,10 +394,14 @@ class DbsliceConfig:
     CLI arguments, with CLI arguments taking precedence.
     """
 
+    version: str | None = None
+    """Optional config schema version tag (currently informational)."""
+
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
     extraction: ExtractionConfig = field(default_factory=ExtractionConfig)
     anonymization: AnonymizationConfig = field(default_factory=AnonymizationConfig)
     output: OutputConfig = field(default_factory=OutputConfig)
+    performance: PerformanceConfig = field(default_factory=PerformanceConfig)
     tables: dict[str, TableOverride] = field(default_factory=dict)
     """Per-table overrides keyed by table name."""
 
@@ -225,24 +462,33 @@ class DbsliceConfig:
         Returns:
             DbsliceConfig object
         """
+        _validate_unknown_keys("root", data, _TOP_LEVEL_KEYS)
+
         database_data = data.get("database", {})
         if not isinstance(database_data, dict):
             raise ValueError("'database' section must be a mapping")
+        _validate_unknown_keys("database", database_data, _DATABASE_KEYS)
+
+        database_options = _normalize_database_options(database_data.get("options"))
 
         database = DatabaseConfig(
             url=database_data.get("url"),
             schema=database_data.get("schema"),
+            options=database_options,
         )
 
         extraction_data = data.get("extraction", {})
         if not isinstance(extraction_data, dict):
             raise ValueError("'extraction' section must be a mapping")
+        _validate_unknown_keys("extraction", extraction_data, _EXTRACTION_KEYS)
 
         extraction = ExtractionConfig(
             default_depth=extraction_data.get("default_depth", DEFAULT_TRAVERSAL_DEPTH),
             direction=extraction_data.get("direction", "both"),
             exclude_tables=extraction_data.get("exclude_tables", []),
             passthrough_tables=extraction_data.get("passthrough_tables", []),
+            validate=extraction_data.get("validate", True),
+            fail_on_validation_error=extraction_data.get("fail_on_validation_error", False),
             max_rows_per_table=extraction_data.get("max_rows_per_table"),
         )
 
@@ -260,47 +506,211 @@ class DbsliceConfig:
 
         if not isinstance(extraction.passthrough_tables, list):
             raise ValueError("'extraction.passthrough_tables' must be a list")
+        if not isinstance(extraction.validate, bool):
+            raise ValueError("'extraction.validate' must be true or false")
+        if not isinstance(extraction.fail_on_validation_error, bool):
+            raise ValueError("'extraction.fail_on_validation_error' must be true or false")
+        if extraction.max_rows_per_table is not None and (
+            not isinstance(extraction.max_rows_per_table, int) or extraction.max_rows_per_table <= 0
+        ):
+            raise ValueError("'extraction.max_rows_per_table' must be a positive integer")
 
         anon_data = data.get("anonymization", {})
         if not isinstance(anon_data, dict):
             raise ValueError("'anonymization' section must be a mapping")
 
+        _validate_unknown_keys("anonymization", anon_data, _ANONYMIZATION_KEYS)
+
         fields = anon_data.get("fields", {})
         if not isinstance(fields, dict):
             raise ValueError("'anonymization.fields' must be a mapping")
+        for field_name, provider in fields.items():
+            _validate_exact_field_key(field_name, "'anonymization.fields'")
+            _validate_faker_provider(provider)
+
+        patterns = anon_data.get("patterns", {})
+        if not isinstance(patterns, dict):
+            raise ValueError("'anonymization.patterns' must be a mapping")
+        for pattern, provider in patterns.items():
+            _validate_glob_field_pattern(pattern, "'anonymization.patterns'")
+            _validate_faker_provider(provider)
+
+        security_null_fields = anon_data.get("security_null_fields", [])
+        if not isinstance(security_null_fields, list):
+            raise ValueError("'anonymization.security_null_fields' must be a list")
+        for pattern in security_null_fields:
+            _validate_glob_field_pattern(pattern, "'anonymization.security_null_fields'")
 
         anonymization = AnonymizationConfig(
             enabled=anon_data.get("enabled", False),
             seed=anon_data.get("seed"),
             fields=fields,
+            patterns=patterns,
+            security_null_fields=security_null_fields,
         )
 
         output_data = data.get("output", {})
         if not isinstance(output_data, dict):
             raise ValueError("'output' section must be a mapping")
 
+        _validate_unknown_keys("output", output_data, _OUTPUT_KEYS)
+
+        include_drop_tables_alias = output_data.get("include_drop_tables")
+        include_truncate = output_data.get("include_truncate")
+
+        if include_drop_tables_alias is not None:
+            logger.warning(
+                "'output.include_drop_tables' is deprecated and treated as "
+                "'output.include_truncate'. This alias will be removed in a future release."
+            )
+            if include_truncate is not None and bool(include_truncate) != bool(include_drop_tables_alias):
+                raise ValueError(
+                    "'output.include_drop_tables' and 'output.include_truncate' disagree. "
+                    "Use only 'output.include_truncate'."
+                )
+            include_truncate = include_drop_tables_alias
+
+        file_mode = output_data.get("file_mode", DEFAULT_OUTPUT_FILE_MODE)
+        from dbslice.utils.fileio import parse_file_mode
+
+        try:
+            parsed_mode = parse_file_mode(file_mode)
+        except ValueError as e:
+            raise ValueError(f"'output.file_mode' is invalid: {e}")
+
+        include_truncate_value = include_truncate if include_truncate is not None else False
+
         output = OutputConfig(
             format=output_data.get("format", "sql"),
             include_transaction=output_data.get("include_transaction", True),
-            include_drop_tables=output_data.get("include_drop_tables", False),
+            include_truncate=include_truncate_value,
+            disable_fk_checks=output_data.get("disable_fk_checks", False),
+            file_mode=parsed_mode,
+            json_mode=output_data.get("json_mode", "auto"),
+            json_pretty=output_data.get("json_pretty", True),
+            csv_mode=output_data.get("csv_mode", "auto"),
+            csv_delimiter=output_data.get("csv_delimiter", ","),
         )
 
         valid_formats = {"sql", "json", "csv"}
         if output.format not in valid_formats:
             raise ValueError(f"'output.format' must be one of: {', '.join(valid_formats)}")
+        if not isinstance(output.include_truncate, bool):
+            raise ValueError("'output.include_truncate' must be true or false")
+        if not isinstance(output.include_transaction, bool):
+            raise ValueError("'output.include_transaction' must be true or false")
+        if not isinstance(output.disable_fk_checks, bool):
+            raise ValueError("'output.disable_fk_checks' must be true or false")
+        if output.json_mode not in {"auto", "single", "per-table"}:
+            raise ValueError("'output.json_mode' must be one of: auto, single, per-table")
+        if not isinstance(output.json_pretty, bool):
+            raise ValueError("'output.json_pretty' must be true or false")
+        if output.csv_mode not in {"auto", "single", "per-table"}:
+            raise ValueError("'output.csv_mode' must be one of: auto, single, per-table")
+        if not isinstance(output.csv_delimiter, str) or len(output.csv_delimiter) != 1:
+            raise ValueError("'output.csv_delimiter' must be a single-character string")
+
+        performance_data = data.get("performance", {})
+        if not isinstance(performance_data, dict):
+            raise ValueError("'performance' section must be a mapping")
+        _validate_unknown_keys("performance", performance_data, _PERFORMANCE_KEYS)
+
+        streaming_data = performance_data.get("streaming", {})
+        if not isinstance(streaming_data, dict):
+            raise ValueError("'performance.streaming' section must be a mapping")
+        _validate_unknown_keys("performance.streaming", streaming_data, _STREAMING_KEYS)
+
+        performance = PerformanceConfig(
+            profile=performance_data.get("profile", False),
+            streaming=StreamingConfig(
+                enabled=streaming_data.get("enabled", False),
+                threshold=streaming_data.get("threshold", DEFAULT_STREAMING_THRESHOLD),
+                chunk_size=streaming_data.get("chunk_size", DEFAULT_STREAMING_CHUNK_SIZE),
+            ),
+            batch_size=performance_data.get("batch_size"),
+        )
+        if not isinstance(performance.profile, bool):
+            raise ValueError("'performance.profile' must be true or false")
+        if not isinstance(performance.streaming.enabled, bool):
+            raise ValueError("'performance.streaming.enabled' must be true or false")
+        if not isinstance(performance.streaming.threshold, int) or performance.streaming.threshold <= 0:
+            raise ValueError("'performance.streaming.threshold' must be a positive integer")
+        if not isinstance(performance.streaming.chunk_size, int) or performance.streaming.chunk_size <= 0:
+            raise ValueError("'performance.streaming.chunk_size' must be a positive integer")
+        if performance.batch_size is not None and (
+            not isinstance(performance.batch_size, int) or performance.batch_size <= 0
+        ):
+            raise ValueError("'performance.batch_size' must be a positive integer")
 
         tables_data = data.get("tables", {})
         if not isinstance(tables_data, dict):
             raise ValueError("'tables' section must be a mapping")
 
         tables = {}
+        valid_directions = {"up", "down", "both"}
         for table_name, table_config in tables_data.items():
             if not isinstance(table_config, dict):
                 raise ValueError(f"Configuration for table '{table_name}' must be a mapping")
+            _validate_unknown_keys(f"tables.{table_name}", table_config, _TABLE_OVERRIDE_KEYS)
+
+            skip_value = table_config.get("skip")
+            exclude_alias = table_config.get("exclude")
+            if skip_value is not None and not isinstance(skip_value, bool):
+                raise ValueError(f"'tables.{table_name}.skip' must be true or false")
+            if exclude_alias is not None and not isinstance(exclude_alias, bool):
+                raise ValueError(f"'tables.{table_name}.exclude' must be true or false")
+            if (
+                skip_value is not None
+                and exclude_alias is not None
+                and bool(skip_value) != bool(exclude_alias)
+            ):
+                raise ValueError(
+                    f"'tables.{table_name}.skip' and 'tables.{table_name}.exclude' disagree. "
+                    "Use only 'skip'."
+                )
+            if exclude_alias is not None:
+                logger.warning(
+                    f"'tables.{table_name}.exclude' is deprecated and treated as "
+                    f"'tables.{table_name}.skip'. This alias will be removed in a future release."
+                )
+            final_skip = bool(skip_value) if skip_value is not None else bool(exclude_alias)
+
+            table_depth = table_config.get("depth")
+            if table_depth is not None and (not isinstance(table_depth, int) or table_depth <= 0):
+                raise ValueError(f"'tables.{table_name}.depth' must be a positive integer")
+
+            table_direction = table_config.get("direction")
+            if table_direction is not None and table_direction not in valid_directions:
+                raise ValueError(
+                    f"'tables.{table_name}.direction' must be one of: "
+                    f"{', '.join(sorted(valid_directions))}"
+                )
+
+            max_rows = table_config.get("max_rows")
+            if max_rows is not None and (not isinstance(max_rows, int) or max_rows <= 0):
+                raise ValueError(f"'tables.{table_name}.max_rows' must be a positive integer")
+
+            anonymize_fields = table_config.get("anonymize_fields", {})
+            if not isinstance(anonymize_fields, dict):
+                raise ValueError(f"'tables.{table_name}.anonymize_fields' must be a mapping")
+            for column_name, provider in anonymize_fields.items():
+                if not isinstance(column_name, str) or not column_name:
+                    raise ValueError(
+                        f"'tables.{table_name}.anonymize_fields' keys must be non-empty strings"
+                    )
+                if "." in column_name or "*" in column_name or "?" in column_name:
+                    raise ValueError(
+                        f"'tables.{table_name}.anonymize_fields' key '{column_name}' must be "
+                        "a bare column name without wildcards"
+                    )
+                _validate_faker_provider(provider)
 
             tables[table_name] = TableOverride(
-                skip=table_config.get("skip", False),
-                max_rows=table_config.get("max_rows"),
+                skip=final_skip,
+                depth=table_depth,
+                direction=table_direction,
+                max_rows=max_rows,
+                anonymize_fields=anonymize_fields,
             )
 
         vfk_data = data.get("virtual_foreign_keys", [])
@@ -311,6 +721,11 @@ class DbsliceConfig:
         for i, vfk_config in enumerate(vfk_data):
             if not isinstance(vfk_config, dict):
                 raise ValueError(f"Virtual FK #{i + 1} must be a mapping")
+            _validate_unknown_keys(
+                f"virtual_foreign_keys[{i}]",
+                vfk_config,
+                _VIRTUAL_FK_KEYS,
+            )
 
             if "source_table" not in vfk_config:
                 raise ValueError(f"Virtual FK #{i + 1}: 'source_table' is required")
@@ -344,10 +759,12 @@ class DbsliceConfig:
             )
 
         return cls(
+            version=data.get("version"),
             database=database,
             extraction=extraction,
             anonymization=anonymization,
             output=output,
+            performance=performance,
             tables=tables,
             virtual_foreign_keys=virtual_fks,
         )
@@ -367,9 +784,13 @@ class DbsliceConfig:
         verbose: bool = False,
         dry_run: bool = False,
         no_progress: bool = False,
-        validate: bool = True,
-        fail_on_validation_error: bool = False,
-        profile: bool = False,
+        validate: bool | None = None,
+        fail_on_validation_error: bool | None = None,
+        profile: bool | None = None,
+        stream: bool | None = None,
+        stream_threshold: int | None = None,
+        stream_chunk_size: int | None = None,
+        output_file_mode: int | None = None,
         schema: str | None = None,
     ) -> ExtractConfig:
         """
@@ -394,6 +815,10 @@ class DbsliceConfig:
             validate: Enable validation (from CLI)
             fail_on_validation_error: Fail on validation errors (from CLI)
             profile: Enable profiling (from CLI)
+            stream: Force streaming mode (from CLI)
+            stream_threshold: Auto-stream threshold override (from CLI)
+            stream_chunk_size: Streaming chunk size override (from CLI)
+            output_file_mode: Output file permissions override (from CLI)
             schema: PostgreSQL schema name override (from CLI)
 
         Returns:
@@ -402,7 +827,18 @@ class DbsliceConfig:
         Raises:
             ValueError: If required fields are missing
         """
-        final_url = database_url or self.database.url
+        final_url: str | None
+        if database_url is not None:
+            final_url = database_url
+            if self.database.options:
+                logger.warning(
+                    "Ignoring 'database.options' because database URL was provided via CLI"
+                )
+        else:
+            final_url = self.database.url
+            if final_url and self.database.options:
+                final_url = _merge_database_url_options(final_url, self.database.options)
+
         if not final_url:
             raise ValueError(
                 "Database URL is required. Provide it via --database-url or in config file under 'database.url'"
@@ -437,13 +873,73 @@ class DbsliceConfig:
             final_passthrough = set(self.extraction.passthrough_tables)
 
         final_anonymize = anonymize if anonymize is not None else self.anonymization.enabled
+        final_validate = validate if validate is not None else self.extraction.validate
+        final_fail_on_validation_error = (
+            fail_on_validation_error
+            if fail_on_validation_error is not None
+            else self.extraction.fail_on_validation_error
+        )
+        final_profile = profile if profile is not None else self.performance.profile
+        final_stream = stream if stream is not None else self.performance.streaming.enabled
+        final_stream_threshold = (
+            stream_threshold
+            if stream_threshold is not None
+            else self.performance.streaming.threshold
+        )
+        final_stream_chunk_size = (
+            stream_chunk_size
+            if stream_chunk_size is not None
+            else self.performance.streaming.chunk_size
+        )
+        final_output_file_mode = (
+            output_file_mode if output_file_mode is not None else self.output.file_mode
+        )
 
-        # Redact fields: merge CLI with config file
+        table_depth_overrides: dict[str, int] = {}
+        table_direction_overrides: dict[str, TraversalDirection] = {}
+        row_limit_per_table: dict[str, int] = {}
+        legacy_table_field_providers: dict[str, str] = {}
+
+        for table_name, override in self.tables.items():
+            if override.depth is not None:
+                table_depth_overrides[table_name] = override.depth
+            if override.direction is not None:
+                table_direction_overrides[table_name] = TraversalDirection(override.direction)
+            if override.max_rows is not None:
+                row_limit_per_table[table_name] = override.max_rows
+
+            if override.anonymize_fields:
+                logger.warning(
+                    f"'tables.{table_name}.anonymize_fields' is deprecated. "
+                    "Use 'anonymization.fields' instead."
+                )
+                for column_name, provider in override.anonymize_fields.items():
+                    field_name = f"{table_name}.{column_name}"
+                    legacy_table_field_providers[field_name] = provider
+
+        effective_field_providers: dict[str, str] = {}
+        if final_anonymize:
+            effective_field_providers.update(legacy_table_field_providers)
+            for field_name, provider in self.anonymization.fields.items():
+                if field_name in effective_field_providers:
+                    logger.warning(
+                        f"Both legacy table anonymization and 'anonymization.fields' define "
+                        f"'{field_name}'. Using 'anonymization.fields'."
+                    )
+                effective_field_providers[field_name] = provider
+
+        effective_patterns = dict(self.anonymization.patterns) if final_anonymize else {}
+        effective_security_null_fields = (
+            list(self.anonymization.security_null_fields) if final_anonymize else []
+        )
+
+        # Redact fields: merge config and CLI (only when anonymization is enabled)
         final_redact: list[str] = []
-        if self.anonymization.fields:
-            final_redact.extend(self.anonymization.fields.keys())
+        if final_anonymize and effective_field_providers:
+            final_redact.extend(effective_field_providers.keys())
         if redact:
             final_redact.extend(redact)
+        final_redact = list(dict.fromkeys(final_redact))
 
         logger.debug(
             "Merged config with CLI args",
@@ -485,9 +981,25 @@ class DbsliceConfig:
             verbose=verbose,
             dry_run=dry_run,
             no_progress=no_progress,
-            validate=validate,
-            fail_on_validation_error=fail_on_validation_error,
-            profile=profile,
+            validate=final_validate,
+            fail_on_validation_error=final_fail_on_validation_error,
+            profile=final_profile,
+            stream=final_stream,
+            streaming_threshold=final_stream_threshold,
+            streaming_chunk_size=final_stream_chunk_size,
+            db_batch_size=self.performance.batch_size,
+            include_transaction=self.output.include_transaction,
+            include_truncate=self.output.include_truncate,
+            disable_fk_checks=self.output.disable_fk_checks,
+            output_file_mode=final_output_file_mode,
+            table_depth_overrides=table_depth_overrides,
+            table_direction_overrides=table_direction_overrides,
+            row_limit_global=self.extraction.max_rows_per_table,
+            row_limit_per_table=row_limit_per_table,
+            anonymization_seed=self.anonymization.seed,
+            anonymization_field_providers=effective_field_providers,
+            anonymization_patterns=effective_patterns,
+            security_null_fields=effective_security_null_fields,
             virtual_foreign_keys=virtual_fks,
             schema=final_schema,
         )
@@ -509,6 +1021,10 @@ class DbsliceConfig:
             output.append("# https://github.com/nabroleonx/dbslice")
             output.append("")
 
+        if self.version:
+            output.append(f'version: "{self.version}"')
+            output.append("")
+
         if include_comments:
             output.append("# Database connection settings")
         output.append("database:")
@@ -526,6 +1042,10 @@ class DbsliceConfig:
             output.append(f"  schema: {self.database.schema}")
         elif include_comments:
             output.append("  # schema: public  # PostgreSQL schema (default: public)")
+        if self.database.options:
+            output.append("  options:")
+            for key, value in self.database.options.items():
+                output.append(f"    {key}: {_yaml_quote(value)}")
         output.append("")
 
         if include_comments:
@@ -533,11 +1053,16 @@ class DbsliceConfig:
         output.append("extraction:")
         output.append(f"  default_depth: {self.extraction.default_depth}")
         output.append(f"  direction: {self.extraction.direction}  # up, down, or both")
+        output.append(f"  validate: {str(self.extraction.validate).lower()}")
+        output.append(
+            "  fail_on_validation_error: "
+            f"{str(self.extraction.fail_on_validation_error).lower()}"
+        )
         if self.extraction.exclude_tables:
             output.append("  exclude_tables:")
             for table in self.extraction.exclude_tables:
                 output.append(f"    - {table}")
-        if self.extraction.max_rows_per_table:
+        if self.extraction.max_rows_per_table is not None:
             output.append(f"  max_rows_per_table: {self.extraction.max_rows_per_table}")
         output.append("")
 
@@ -551,6 +1076,14 @@ class DbsliceConfig:
             output.append("  fields:")
             for field, provider in self.anonymization.fields.items():
                 output.append(f"    {field}: {provider}")
+        if self.anonymization.patterns:
+            output.append("  patterns:")
+            for pattern, provider in self.anonymization.patterns.items():
+                output.append(f"    {_yaml_quote(pattern)}: {_yaml_quote(provider)}")
+        if self.anonymization.security_null_fields:
+            output.append("  security_null_fields:")
+            for pattern in self.anonymization.security_null_fields:
+                output.append(f"    - {_yaml_quote(pattern)}")
         output.append("")
 
         if include_comments:
@@ -558,7 +1091,29 @@ class DbsliceConfig:
         output.append("output:")
         output.append(f"  format: {self.output.format}  # sql, json, or csv")
         output.append(f"  include_transaction: {str(self.output.include_transaction).lower()}")
-        output.append(f"  include_drop_tables: {str(self.output.include_drop_tables).lower()}")
+        output.append(f"  include_truncate: {str(self.output.include_truncate).lower()}")
+        output.append(f"  disable_fk_checks: {str(self.output.disable_fk_checks).lower()}")
+        output.append(f"  file_mode: \"{self.output.file_mode:o}\"")
+        output.append(f"  json_mode: {self.output.json_mode}")
+        output.append(f"  json_pretty: {str(self.output.json_pretty).lower()}")
+        output.append(f"  csv_mode: {self.output.csv_mode}")
+        output.append(f"  csv_delimiter: \"{self.output.csv_delimiter}\"")
+        if include_comments:
+            output.append(
+                "  # Backward-compatible alias accepted: include_drop_tables (deprecated)"
+            )
+        output.append("")
+
+        if include_comments:
+            output.append("# Performance settings")
+        output.append("performance:")
+        output.append(f"  profile: {str(self.performance.profile).lower()}")
+        output.append("  streaming:")
+        output.append(f"    enabled: {str(self.performance.streaming.enabled).lower()}")
+        output.append(f"    threshold: {self.performance.streaming.threshold}")
+        output.append(f"    chunk_size: {self.performance.streaming.chunk_size}")
+        if self.performance.batch_size is not None:
+            output.append(f"  batch_size: {self.performance.batch_size}")
         output.append("")
 
         if self.tables:
@@ -569,8 +1124,20 @@ class DbsliceConfig:
                 output.append(f"  {table_name}:")
                 if override.skip:
                     output.append("    skip: true")
+                if override.depth is not None:
+                    output.append(f"    depth: {override.depth}")
+                if override.direction is not None:
+                    output.append(f"    direction: {override.direction}")
                 if override.max_rows is not None:
                     output.append(f"    max_rows: {override.max_rows}")
+                if override.anonymize_fields:
+                    output.append("    anonymize_fields:")
+                    for column_name, provider in override.anonymize_fields.items():
+                        output.append(f"      {column_name}: {provider}")
+                    if include_comments:
+                        output.append(
+                            "    # Deprecated: prefer top-level anonymization.fields"
+                        )
             output.append("")
 
         if self.virtual_foreign_keys:

--- a/src/dbslice/constants.py
+++ b/src/dbslice/constants.py
@@ -21,3 +21,12 @@ MAX_AVAILABLE_COLUMNS_DISPLAY = 10
 
 DEFAULT_ANONYMIZATION_SEED = "dbslice_default_seed"
 """Default seed value for deterministic anonymization."""
+
+DEFAULT_STREAMING_THRESHOLD = 50000
+"""Auto-enable streaming mode above this row count."""
+
+DEFAULT_STREAMING_CHUNK_SIZE = 1000
+"""Default number of rows per chunk in streaming mode."""
+
+DEFAULT_OUTPUT_FILE_MODE = 0o600
+"""Secure default permissions for newly created output files."""

--- a/src/dbslice/core/engine.py
+++ b/src/dbslice/core/engine.py
@@ -11,14 +11,14 @@ from dbslice.config import (
     SeedSpec,
     TraversalDirection,
 )
-from dbslice.constants import DEFAULT_TRAVERSAL_DEPTH
+from dbslice.constants import DEFAULT_ANONYMIZATION_SEED, DEFAULT_TRAVERSAL_DEPTH
 from dbslice.core.graph import GraphTraverser, TraversalConfig, TraversalResult
 from dbslice.exceptions import (
     NoRowsFoundError,
     TableNotFoundError,
 )
 from dbslice.logging import get_logger
-from dbslice.models import SchemaGraph
+from dbslice.models import ForeignKey, SchemaGraph
 from dbslice.output.sql import SQLGenerator
 from dbslice.utils.anonymizer import DeterministicAnonymizer
 from dbslice.utils.connection import get_adapter_for_url, parse_database_url
@@ -118,9 +118,15 @@ class ExtractionEngine:
         # Initialize anonymizer if needed (schema will be set after introspection)
         self.anonymizer: DeterministicAnonymizer | None = None
         if config.anonymize or config.redact_fields:
-            self.anonymizer = DeterministicAnonymizer()
-            if config.redact_fields:
-                self.anonymizer.configure(config.redact_fields)
+            self.anonymizer = DeterministicAnonymizer(
+                seed=config.anonymization_seed or DEFAULT_ANONYMIZATION_SEED
+            )
+            self.anonymizer.configure(
+                config.redact_fields,
+                field_providers=config.anonymization_field_providers,
+                patterns=config.anonymization_patterns,
+                security_null_fields=config.security_null_fields,
+            )
 
     def _log(self, stage: str, message: str, current: int = 0, total: int = 0) -> None:
         """Send progress update to callback if configured."""
@@ -159,6 +165,7 @@ class ExtractionEngine:
 
         if db_config.db_type.value == "postgresql":
             self.adapter = PostgreSQLAdapter(
+                batch_size=self.config.db_batch_size,
                 profiler=profiler,
                 schema=self.config.schema,
             )
@@ -382,6 +389,19 @@ class ExtractionEngine:
             stats[table] = len(rows)
             logger.debug("Table data fetched", table=table, row_count=len(rows))
 
+        if self._has_row_limits():
+            self._log("limits", "Applying deterministic row limits with integrity closure...")
+            with logger.timed_operation("apply_row_limits"):
+                tables_data = self._apply_row_limits(tables_data)
+            stats = {table: len(rows) for table, rows in tables_data.items()}
+            logger.info(
+                "Row limits applied",
+                global_limit=self.config.row_limit_global,
+                per_table_limits=len(self.config.row_limit_per_table),
+                total_rows=sum(stats.values()),
+            )
+            self._log("limits", "Row limits applied")
+
         deferred_updates = []
         if broken_fks:
             from dbslice.core.cycles import build_deferred_updates
@@ -470,6 +490,140 @@ class ExtractionEngine:
 
         return [self.anonymizer.anonymize_row(table, row) for row in rows]
 
+    def _has_row_limits(self) -> bool:
+        """Check whether any row-limit configuration is active."""
+        return self.config.row_limit_global is not None or bool(self.config.row_limit_per_table)
+
+    def _row_limit_for_table(self, table: str) -> int | None:
+        """Resolve effective row limit for a table."""
+        if table in self.config.row_limit_per_table:
+            return self.config.row_limit_per_table[table]
+        return self.config.row_limit_global
+
+    def _row_sort_key(self, table: str, row: dict[str, Any]) -> tuple[Any, ...]:
+        """Build a deterministic sort key for row selection."""
+        assert self.schema is not None
+        table_info = self.schema.get_table(table)
+        if table_info and table_info.primary_key:
+            return tuple((row.get(col) is None, repr(row.get(col))) for col in table_info.primary_key)
+        # Fallback for tables without primary key
+        return tuple((k, repr(v)) for k, v in sorted(row.items()))
+
+    def _row_identity(
+        self, table: str, row: dict[str, Any], index: int
+    ) -> tuple[Any, ...]:
+        """Build a stable identity key for selected/candidate rows."""
+        assert self.schema is not None
+        table_info = self.schema.get_table(table)
+        if table_info and table_info.primary_key:
+            return ("pk",) + tuple(row.get(col) for col in table_info.primary_key)
+        return ("idx", index)
+
+    def _apply_row_limits(
+        self, tables_data: dict[str, list[dict[str, Any]]]
+    ) -> dict[str, list[dict[str, Any]]]:
+        """
+        Apply deterministic row limits and expand parent closure to preserve FK integrity.
+
+        Limits are treated as soft caps: required parent rows are added even if
+        that exceeds the configured cap.
+        """
+        assert self.schema is not None
+        if not tables_data or not self._has_row_limits():
+            return tables_data
+
+        candidate_rows_by_id: dict[str, dict[tuple[Any, ...], dict[str, Any]]] = {}
+        selected_ids: dict[str, dict[tuple[Any, ...], None]] = {}
+        sorted_rows: dict[str, list[dict[str, Any]]] = {}
+        effective_limits: dict[str, int] = {}
+
+        for table, rows in tables_data.items():
+            ordered_rows = sorted(rows, key=lambda row: self._row_sort_key(table, row))
+            sorted_rows[table] = ordered_rows
+
+            table_candidates: dict[tuple[Any, ...], dict[str, Any]] = {}
+            table_selected: dict[tuple[Any, ...], None] = {}
+            limit = self._row_limit_for_table(table)
+            if limit is not None:
+                effective_limits[table] = limit
+
+            for idx, row in enumerate(ordered_rows):
+                row_id = self._row_identity(table, row, idx)
+                table_candidates[row_id] = row
+
+            selected_count = len(ordered_rows) if limit is None else min(limit, len(ordered_rows))
+            for idx in range(selected_count):
+                row_id = self._row_identity(table, ordered_rows[idx], idx)
+                table_selected[row_id] = None
+
+            candidate_rows_by_id[table] = table_candidates
+            selected_ids[table] = table_selected
+
+        lookup_cache: dict[tuple[str, tuple[str, ...]], dict[tuple[Any, ...], list[tuple[Any, ...]]]] = {}
+
+        def _lookup_for(table: str, columns: tuple[str, ...]) -> dict[tuple[Any, ...], list[tuple[Any, ...]]]:
+            cache_key = (table, columns)
+            if cache_key in lookup_cache:
+                return lookup_cache[cache_key]
+
+            lookup: dict[tuple[Any, ...], list[tuple[Any, ...]]] = {}
+            for row_id, row in candidate_rows_by_id.get(table, {}).items():
+                key = tuple(row.get(col) for col in columns)
+                if None in key:
+                    continue
+                lookup.setdefault(key, []).append(row_id)
+            lookup_cache[cache_key] = lookup
+            return lookup
+
+        changed = True
+        while changed:
+            changed = False
+            for source_table in sorted(selected_ids.keys()):
+                if source_table not in self.schema.tables:
+                    continue
+                source_selected_ids = list(selected_ids[source_table].keys())
+                if not source_selected_ids:
+                    continue
+
+                parent_edges = sorted(
+                    self.schema.get_parents(source_table),
+                    key=lambda item: (item[0], item[1].name),
+                )
+                for parent_table, fk in parent_edges:
+                    if parent_table not in candidate_rows_by_id:
+                        continue
+                    assert isinstance(fk, ForeignKey)
+                    parent_lookup = _lookup_for(parent_table, fk.target_columns)
+                    parent_selected = selected_ids.setdefault(parent_table, {})
+
+                    for source_id in source_selected_ids:
+                        source_row = candidate_rows_by_id[source_table][source_id]
+                        source_key = tuple(source_row.get(col) for col in fk.source_columns)
+                        if None in source_key:
+                            continue
+                        parent_row_ids = parent_lookup.get(source_key, [])
+                        for parent_row_id in parent_row_ids:
+                            if parent_row_id not in parent_selected:
+                                parent_selected[parent_row_id] = None
+                                changed = True
+
+        limited_tables: dict[str, list[dict[str, Any]]] = {}
+        for table in tables_data.keys():
+            table_selected = selected_ids.get(table, {})
+            limited_rows = [candidate_rows_by_id[table][row_id] for row_id in table_selected.keys()]
+            limited_tables[table] = limited_rows
+
+            limit = effective_limits.get(table)
+            if limit is not None and len(limited_rows) > limit:
+                logger.info(
+                    "Row limit soft cap exceeded to preserve FK integrity",
+                    table=table,
+                    configured_limit=limit,
+                    final_rows=len(limited_rows),
+                )
+
+        return limited_tables
+
     def _process_seed(self, seed: SeedSpec) -> TraversalResult:
         """Process a single seed and return traversal result."""
         assert self.schema is not None
@@ -503,6 +657,8 @@ class ExtractionEngine:
             direction=self.config.direction,
             exclude_tables=self.config.exclude_tables,
             passthrough_tables=self.config.passthrough_tables,
+            table_depth_overrides=self.config.table_depth_overrides,
+            table_direction_overrides=self.config.table_direction_overrides,
         )
 
         traverser = GraphTraverser(self.schema, self.adapter)
@@ -520,11 +676,21 @@ class ExtractionEngine:
         """
         # Force streaming if explicitly enabled
         if self.config.stream:
+            if self._has_row_limits():
+                logger.warning(
+                    "Streaming disabled because row limits are configured and require in-memory integrity closure"
+                )
+                return False
             logger.debug("Streaming enabled via --stream flag")
             return True
 
         # Auto-enable streaming if above threshold and output file is specified
         if total_rows >= self.config.streaming_threshold and self.config.output_file:
+            if self._has_row_limits():
+                logger.warning(
+                    "Streaming disabled because row limits are configured and require in-memory integrity closure"
+                )
+                return False
             logger.debug(
                 "Auto-enabling streaming mode",
                 total_rows=total_rows,

--- a/src/dbslice/core/graph.py
+++ b/src/dbslice/core/graph.py
@@ -19,6 +19,8 @@ class TraversalConfig:
     direction: TraversalDirection = TraversalDirection.BOTH
     exclude_tables: set[str] = field(default_factory=set)
     passthrough_tables: set[str] = field(default_factory=set)
+    table_depth_overrides: dict[str, int] = field(default_factory=dict)
+    table_direction_overrides: dict[str, TraversalDirection] = field(default_factory=dict)
 
 
 @dataclass
@@ -73,6 +75,17 @@ class GraphTraverser:
         self.schema = schema
         self.adapter = adapter
 
+    @staticmethod
+    def _direction_allows(direction: str, effective: TraversalDirection) -> bool:
+        """Check whether a queued traversal direction is allowed for a table."""
+        if direction == "up":
+            # Always allow upward traversals because DOWN mode schedules
+            # upward closure from children to preserve referential integrity.
+            return True
+        if direction == "down":
+            return effective in (TraversalDirection.DOWN, TraversalDirection.BOTH)
+        return False
+
     def traverse(
         self,
         seed_table: str,
@@ -111,10 +124,12 @@ class GraphTraverser:
         # Queue: (table, pk_set, depth, direction)
         queue: deque[tuple[str, set[tuple[Any, ...]], int, str]] = deque()
 
-        if config.direction in (TraversalDirection.UP, TraversalDirection.BOTH):
+        seed_direction = config.table_direction_overrides.get(seed_table, config.direction)
+
+        if seed_direction in (TraversalDirection.UP, TraversalDirection.BOTH):
             queue.append((seed_table, seed_pks, 0, "up"))
 
-        if config.direction in (TraversalDirection.DOWN, TraversalDirection.BOTH):
+        if seed_direction in (TraversalDirection.DOWN, TraversalDirection.BOTH):
             queue.append((seed_table, seed_pks, 0, "down"))
 
         # Track visited in each direction to avoid re-processing
@@ -124,12 +139,23 @@ class GraphTraverser:
         while queue:
             table, pks, depth, direction = queue.popleft()
 
-            if depth >= config.max_depth and direction == "down":
+            effective_direction = config.table_direction_overrides.get(table, config.direction)
+            if not self._direction_allows(direction, effective_direction):
+                logger.debug(
+                    "Skipping traversal direction due to table override",
+                    table=table,
+                    queued_direction=direction,
+                    effective_direction=effective_direction.value,
+                )
+                continue
+
+            effective_depth = config.table_depth_overrides.get(table, config.max_depth)
+            if depth >= effective_depth and direction == "down":
                 logger.debug(
                     "Max depth reached for downward traversal, skipping",
                     table=table,
                     depth=depth,
-                    max_depth=config.max_depth,
+                    max_depth=effective_depth,
                 )
                 continue
 

--- a/src/dbslice/core/streaming.py
+++ b/src/dbslice/core/streaming.py
@@ -3,11 +3,13 @@ from typing import Any, TextIO
 
 from dbslice.adapters.base import DatabaseAdapter
 from dbslice.config import DatabaseType, ExtractConfig
+from dbslice.constants import DEFAULT_ANONYMIZATION_SEED
 from dbslice.core.engine import ExtractionResult, ProgressCallback
 from dbslice.logging import get_logger
 from dbslice.models import SchemaGraph, Table
 from dbslice.output.sql import SQLGenerator
 from dbslice.utils.anonymizer import DeterministicAnonymizer
+from dbslice.utils.fileio import open_text_file_secure
 
 logger = get_logger(__name__)
 
@@ -70,16 +72,22 @@ class StreamingExtractionEngine:
         # Initialize anonymizer if needed
         self.anonymizer: DeterministicAnonymizer | None = None
         if config.anonymize or config.redact_fields:
-            self.anonymizer = DeterministicAnonymizer()
+            self.anonymizer = DeterministicAnonymizer(
+                seed=config.anonymization_seed or DEFAULT_ANONYMIZATION_SEED
+            )
             self.anonymizer.schema = schema
-            if config.redact_fields:
-                self.anonymizer.configure(config.redact_fields)
+            self.anonymizer.configure(
+                config.redact_fields,
+                field_providers=config.anonymization_field_providers,
+                patterns=config.anonymization_patterns,
+                security_null_fields=config.security_null_fields,
+            )
 
         self.sql_generator = SQLGenerator(
             db_type=db_type,
-            include_transaction=True,
-            include_truncate=False,
-            disable_fk_checks=False,
+            include_transaction=config.include_transaction,
+            include_truncate=config.include_truncate,
+            disable_fk_checks=config.disable_fk_checks,
             schema=config.schema,
         )
 
@@ -119,7 +127,7 @@ class StreamingExtractionEngine:
         broken_fk_cols = self._build_broken_fk_map()
 
         try:
-            with open(output_file, "w") as f:
+            with open_text_file_secure(output_file, file_mode=self.config.output_file_mode) as f:
                 # Write header
                 self._write_header(f, total_tables)
 
@@ -253,12 +261,31 @@ class StreamingExtractionEngine:
         if self.broken_fks:
             f.write(f"-- Circular references detected: {len(self.broken_fks)} FK(s) broken\n")
         f.write("\n")
-        f.write("BEGIN;\n")
-        f.write("\n")
+
+        if self.config.disable_fk_checks:
+            f.write(self.sql_generator._disable_fk_checks() + "\n")
+            f.write("\n")
+
+        if self.config.include_transaction:
+            f.write("BEGIN;\n")
+            f.write("\n")
+
+        if self.config.include_truncate:
+            for table in self.insert_order:
+                if table in self.records:
+                    f.write(
+                        "TRUNCATE TABLE "
+                        f"{self.sql_generator._quote_identifier(table)} CASCADE;\n"
+                    )
+            f.write("\n")
 
     def _write_footer(self, f: TextIO) -> None:
         """Write SQL file footer."""
-        f.write("COMMIT;\n")
+        if self.config.include_transaction:
+            f.write("COMMIT;\n")
+        if self.config.disable_fk_checks:
+            f.write("\n")
+            f.write(self.sql_generator._enable_fk_checks() + "\n")
 
     def _write_deferred_updates(self, f: TextIO) -> None:
         """Write deferred UPDATE statements for broken FKs."""

--- a/src/dbslice/input_validators.py
+++ b/src/dbslice/input_validators.py
@@ -6,6 +6,7 @@ which validates extracted *data* for referential integrity post-extraction.
 """
 
 import re
+from os import W_OK, access
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,7 @@ from dbslice.constants import (
     MAX_TRAVERSAL_DEPTH,
     MIN_TRAVERSAL_DEPTH,
 )
+from dbslice.utils.fileio import parse_file_mode
 
 
 class ValidationError(Exception):
@@ -85,6 +87,15 @@ DATABASE_URL_PATTERN = re.compile(
 )
 
 SQLITE_URL_PATTERN = re.compile(r"^sqlite:///(.+)$")
+
+
+def _is_subpath(path: Path, base: Path) -> bool:
+    """Return True if path is equal to or contained within base."""
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
 
 
 def validate_identifier(identifier: str, identifier_type: str = "identifier") -> None:
@@ -396,25 +407,65 @@ def validate_output_file_path(path: str | Path) -> None:
             "Please create the directory first or use an existing directory.",
         )
 
-    # Check if parent is writable (if it exists)
-    if parent.exists() and not parent.is_dir():
-        raise FilePathValidationError(str(path), f"Parent path is not a directory: {parent}")
-
-    # Check for dangerous paths (only if parent exists to avoid false positives)
+    # Check for dangerous paths (using canonical paths to prevent symlink bypasses).
     if parent.exists():
         try:
-            resolved = path_obj.resolve()
-            # Check if trying to write to system directories
-            dangerous_paths = ["/bin", "/sbin", "/usr/bin", "/usr/sbin", "/etc", "/sys", "/proc"]
+            resolved_target = path_obj.resolve()
+            resolved_parent = parent.resolve()
+            # Check if trying to write to system directories.
+            dangerous_paths = [
+                "/bin",
+                "/sbin",
+                "/usr/bin",
+                "/usr/sbin",
+                "/etc",
+                "/private/etc",
+                "/sys",
+                "/proc",
+            ]
             for dangerous in dangerous_paths:
-                if str(resolved).startswith(dangerous):
+                dangerous_path = Path(dangerous).resolve()
+                if _is_subpath(resolved_target, dangerous_path) or _is_subpath(
+                    resolved_parent, dangerous_path
+                ):
                     raise FilePathValidationError(
                         str(path),
-                        f"Cannot write to system directory: {dangerous}\n"
+                        f"Cannot write to system directory: {dangerous_path}\n"
                         "Please choose a different output location.",
                     )
         except (OSError, RuntimeError) as e:
             raise FilePathValidationError(str(path), f"Invalid path: {e}")
+
+    # Check if parent is writable (if it exists)
+    if parent.exists() and not parent.is_dir():
+        raise FilePathValidationError(str(path), f"Parent path is not a directory: {parent}")
+    if parent.exists() and not access(parent, W_OK):
+        raise FilePathValidationError(
+            str(path),
+            f"Parent directory is not writable: {parent}",
+        )
+
+
+def validate_output_file_mode(mode: str | int | None) -> int:
+    """
+    Validate and normalize output file mode.
+
+    Args:
+        mode: Octal string (e.g., "600", "0o600") or integer
+
+    Returns:
+        Parsed integer file mode
+
+    Raises:
+        ValidationError: If mode is invalid
+    """
+    if mode is None:
+        raise ValidationError("File mode cannot be None")
+
+    try:
+        return parse_file_mode(mode)
+    except ValueError as e:
+        raise ValidationError(str(e))
 
 
 def validate_exclude_tables(tables: list[str]) -> None:

--- a/src/dbslice/output/csv_out.py
+++ b/src/dbslice/output/csv_out.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
+from dbslice.constants import DEFAULT_OUTPUT_FILE_MODE
 from dbslice.models import Table
+from dbslice.utils.fileio import write_text_file_secure
 
 
 class CSVGenerator:
@@ -267,6 +269,7 @@ class CSVGenerator:
         self,
         output: str | dict[str, str],
         file_path: Path | str,
+        file_mode: int = DEFAULT_OUTPUT_FILE_MODE,
     ) -> None:
         """
         Write CSV output to file(s).
@@ -286,7 +289,7 @@ class CSVGenerator:
                 raise ValueError("Single mode output must be a string")
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.write_text(output, encoding="utf-8")
+            write_text_file_secure(file_path, output, file_mode=file_mode, encoding="utf-8")
         else:
             if not isinstance(output, dict):
                 raise ValueError("Per-table mode output must be a dict")
@@ -295,7 +298,7 @@ class CSVGenerator:
 
             for table_name, csv_str in output.items():
                 table_file = file_path / f"{table_name}.csv"
-                table_file.write_text(csv_str, encoding="utf-8")
+                write_text_file_secure(table_file, csv_str, file_mode=file_mode, encoding="utf-8")
 
 
 def generate_csv(

--- a/src/dbslice/output/json_out.py
+++ b/src/dbslice/output/json_out.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
+from dbslice.constants import DEFAULT_OUTPUT_FILE_MODE
 from dbslice.models import Table
+from dbslice.utils.fileio import write_text_file_secure
 
 
 class DatabaseTypeEncoder(json.JSONEncoder):
@@ -248,6 +250,7 @@ class JSONGenerator:
         self,
         output: str | dict[str, str],
         file_path: Path | str,
+        file_mode: int = DEFAULT_OUTPUT_FILE_MODE,
     ) -> None:
         """
         Write JSON output to file(s).
@@ -267,7 +270,7 @@ class JSONGenerator:
                 raise ValueError("Single mode output must be a string")
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.write_text(output, encoding="utf-8")
+            write_text_file_secure(file_path, output, file_mode=file_mode, encoding="utf-8")
         else:
             if not isinstance(output, dict):
                 raise ValueError("Per-table mode output must be a dict")
@@ -276,7 +279,7 @@ class JSONGenerator:
 
             for table_name, json_str in output.items():
                 table_file = file_path / f"{table_name}.json"
-                table_file.write_text(json_str, encoding="utf-8")
+                write_text_file_secure(table_file, json_str, file_mode=file_mode, encoding="utf-8")
 
 
 def generate_json(

--- a/src/dbslice/utils/anonymizer.py
+++ b/src/dbslice/utils/anonymizer.py
@@ -1,4 +1,5 @@
 import hashlib
+from fnmatch import fnmatchcase
 from typing import TYPE_CHECKING, Any
 
 from dbslice.constants import DEFAULT_ANONYMIZATION_SEED
@@ -46,14 +47,14 @@ _DEFAULT_ANONYMIZATION_PATTERNS: dict[str, str] = {
     "card_number": "credit_card_number",
     "card": "credit_card_number",
     "passport": "passport_number",
-    "driver_license": "driver_license",
-    "driverlicense": "driver_license",
-    "license_number": "driver_license",
+    "driver_license": "license_plate",
+    "driverlicense": "license_plate",
+    "license_number": "license_plate",
     # Financial
     "iban": "iban",
     "bank_account": "bban",
     "account_number": "bban",
-    "routing_number": "routing_number",
+    "routing_number": "aba",
     "swift": "swift",
     # Network
     "ip_address": "ipv4",
@@ -145,19 +146,98 @@ class DeterministicAnonymizer:
         self.global_seed = seed
         self.fake = Faker()
         self._cache: dict[tuple, Any] = {}
-        self.redact_fields: set[str] = set()  # Set of "table.column"
+        self.redact_fields: set[str] = set()  # Set of normalized "table.column"
+        self.field_providers: dict[str, str] = {}
+        self.custom_patterns: list[tuple[str, str]] = []
+        self.security_null_fields: list[str] = []
         self.schema = schema
         self._fk_columns_cache: dict[str, set[str]] = {}  # Cache of FK columns per table
 
-    def configure(self, redact_fields: list[str]):
+    def _normalize_field(self, table: str, column: str) -> str:
+        """Return normalized table.column field name for matching."""
+        return f"{table}.{column}".lower()
+
+    def _match_glob(self, pattern: str, field: str) -> bool:
+        """Case-insensitive shell-style glob match for table.column patterns."""
+        return fnmatchcase(field, pattern.lower())
+
+    def _resolve_custom_pattern_provider(self, table: str, column: str) -> str | None:
         """
-        Configure additional fields to redact.
+        Resolve provider from custom wildcard patterns.
+
+        Resolution policy:
+        - Most specific pattern wins (longest non-wildcard literal).
+        - Ties are resolved by declaration order (first wins).
+        """
+        field = self._normalize_field(table, column)
+        best_provider: str | None = None
+        best_specificity = -1
+
+        for pattern, provider in self.custom_patterns:
+            if not self._match_glob(pattern, field):
+                continue
+
+            specificity = sum(1 for ch in pattern if ch not in {"*", "?"})
+            if specificity > best_specificity:
+                best_provider = provider
+                best_specificity = specificity
+
+        return best_provider
+
+    def _resolve_exact_field_provider(self, table: str, column: str) -> str | None:
+        """Resolve provider from exact field mappings."""
+        return self.field_providers.get(self._normalize_field(table, column))
+
+    def _resolve_faker_method(self, table: str, column: str) -> str:
+        """
+        Resolve faker method with precedence:
+        1. Exact field provider mapping
+        2. Custom wildcard pattern mapping
+        3. Built-in column substring mapping
+        4. pystr fallback
+        """
+        exact_provider = self._resolve_exact_field_provider(table, column)
+        if exact_provider:
+            return exact_provider
+
+        pattern_provider = self._resolve_custom_pattern_provider(table, column)
+        if pattern_provider:
+            return pattern_provider
+
+        return self.get_faker_method(column)
+
+    def configure(
+        self,
+        redact_fields: list[str],
+        field_providers: dict[str, str] | None = None,
+        patterns: dict[str, str] | None = None,
+        security_null_fields: list[str] | None = None,
+    ):
+        """
+        Configure custom anonymization behavior.
 
         Args:
-            redact_fields: List of fields in "table.column" format
+            redact_fields: List of exact fields in "table.column" format.
+            field_providers: Exact field to faker-provider mappings.
+            patterns: Wildcard table.column glob to faker-provider mappings.
+            security_null_fields: Wildcard table.column globs to force NULL.
         """
-        self.redact_fields = set(redact_fields)
-        logger.info("Anonymizer configured", redact_field_count=len(redact_fields))
+        self.redact_fields = {field.lower() for field in redact_fields}
+        self.field_providers = {
+            field.lower(): provider for field, provider in (field_providers or {}).items()
+        }
+        self.custom_patterns = [
+            (pattern.lower(), provider) for pattern, provider in (patterns or {}).items()
+        ]
+        self.security_null_fields = [pattern.lower() for pattern in (security_null_fields or [])]
+
+        logger.info(
+            "Anonymizer configured",
+            redact_field_count=len(self.redact_fields),
+            exact_provider_count=len(self.field_providers),
+            pattern_count=len(self.custom_patterns),
+            security_null_pattern_count=len(self.security_null_fields),
+        )
 
     def _is_foreign_key_column(self, table: str, column: str) -> bool:
         """
@@ -178,10 +258,8 @@ class DeterministicAnonymizer:
 
         if table not in self._fk_columns_cache:
             fk_columns: set[str] = set()
-            table_info = self.schema.get_table(table)
-            if table_info:
-                for fk in table_info.foreign_keys:
-                    fk_columns.update(fk.source_columns)
+            for _, fk in self.schema.get_parents(table):
+                fk_columns.update(fk.source_columns)
             self._fk_columns_cache[table] = fk_columns
 
         return column in self._fk_columns_cache[table]
@@ -205,10 +283,18 @@ class DeterministicAnonymizer:
         if self._is_foreign_key_column(table, column):
             return False
 
-        full_name = f"{table}.{column}"
+        full_name = self._normalize_field(table, column)
 
         # Explicitly marked for redaction
         if full_name in self.redact_fields:
+            return True
+
+        # Exact field mapping always enables anonymization
+        if full_name in self.field_providers:
+            return True
+
+        # Custom wildcard patterns
+        if self._resolve_custom_pattern_provider(table, column):
             return True
 
         # Pattern matching on column name
@@ -230,6 +316,15 @@ class DeterministicAnonymizer:
         Returns:
             True if column should be NULLed
         """
+        # FK columns are never nulled to preserve referential integrity
+        if self._is_foreign_key_column(table, column):
+            return False
+
+        field = self._normalize_field(table, column)
+        for pattern in self.security_null_fields:
+            if self._match_glob(pattern, field):
+                return True
+
         col_lower = column.lower()
         for pattern in _SECURITY_NULL_PATTERNS:
             if pattern in col_lower:
@@ -262,13 +357,13 @@ class DeterministicAnonymizer:
         in-memory cache keyed by (value, column) to ensure consistency.
 
         Cache Behavior:
-            - Cache key: (str(value), column)
+            - Cache key: (str(value), column, resolved_faker_method)
             - Same value in same column type gets identical output across tables
             - Example: "john@example.com" in any "email" column → same fake email
             - This preserves referential integrity when values appear multiple times
 
         Determinism:
-            - Uses SHA-256 hash of (global_seed:column:value) as Faker seed
+            - Uses SHA-256 hash of (global_seed:column:method:value) as Faker seed
             - Column name is included to differentiate same values in different contexts
             - Example: "john" as first_name vs last_name may produce different outputs
 
@@ -283,23 +378,27 @@ class DeterministicAnonymizer:
         if value is None:
             return None
 
+        # FK integrity has highest priority over nulling/anonymization rules.
+        if self._is_foreign_key_column(table, column):
+            return value
+
         if self.should_null(table, column):
             return None
 
         if not self.should_anonymize(table, column):
             return value
 
-        cache_key = (str(value), column)
+        faker_method = self._resolve_faker_method(table, column)
+        cache_key = (str(value), column, faker_method)
         if cache_key in self._cache:
             return self._cache[cache_key]
 
-        # Generate deterministic seed from global seed + column name + original value
+        # Generate deterministic seed from global seed + column/provider + original value
         # Including column name ensures same value in different column types gets different output
-        hash_input = f"{self.global_seed}:{column}:{value}".encode()
+        hash_input = f"{self.global_seed}:{column}:{faker_method}:{value}".encode()
         seed_int = int.from_bytes(hashlib.sha256(hash_input).digest()[:8], "big")
 
         self.fake.seed_instance(seed_int)
-        faker_method = self.get_faker_method(column)
 
         try:
             anonymized = getattr(self.fake, faker_method)()
@@ -350,4 +449,7 @@ class DeterministicAnonymizer:
         return {
             "cache_size": len(self._cache),
             "redact_fields_count": len(self.redact_fields),
+            "exact_provider_count": len(self.field_providers),
+            "pattern_count": len(self.custom_patterns),
+            "security_null_pattern_count": len(self.security_null_fields),
         }

--- a/src/dbslice/utils/fileio.py
+++ b/src/dbslice/utils/fileio.py
@@ -1,0 +1,58 @@
+import os
+import re
+from pathlib import Path
+from typing import TextIO
+
+
+def parse_file_mode(mode: int | str) -> int:
+    """Parse a file mode from int or octal string."""
+    if isinstance(mode, int):
+        parsed = mode
+    else:
+        normalized = mode.strip().lower()
+        if normalized.startswith("0o"):
+            normalized = normalized[2:]
+        if not re.fullmatch(r"[0-7]{3,4}", normalized):
+            raise ValueError(
+                "File mode must be an octal value like 600 or 0o600 (range 000-777)"
+            )
+        parsed = int(normalized, 8)
+
+    if parsed < 0 or parsed > 0o777:
+        raise ValueError("File mode must be between 000 and 777 (octal)")
+
+    return parsed
+
+
+def open_text_file_secure(
+    path: str | Path,
+    file_mode: int,
+    encoding: str = "utf-8",
+) -> TextIO:
+    """
+    Open a text file for writing with explicit permissions.
+
+    Uses os.open/os.fdopen so the requested mode is applied on creation,
+    and reapplied to existing files for deterministic hardening behavior.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(Path(path), flags, file_mode)
+    try:
+        # Enforce permissions even when the file already exists.
+        os.fchmod(fd, file_mode)
+    except OSError:
+        # Keep best effort behavior on platforms that may not support fchmod.
+        pass
+
+    return os.fdopen(fd, "w", encoding=encoding)
+
+
+def write_text_file_secure(
+    path: str | Path,
+    content: str,
+    file_mode: int,
+    encoding: str = "utf-8",
+) -> None:
+    """Write text to a file with explicit permissions."""
+    with open_text_file_secure(path, file_mode=file_mode, encoding=encoding) as f:
+        f.write(content)

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -547,6 +547,101 @@ class TestCLIStreaming:
             if os.path.exists(output_file):
                 os.unlink(output_file)
 
+
+class TestCLIConfigParity:
+    """Test that runtime flags behave the same with --config."""
+
+    def test_cli_no_validate_with_config(self, ecommerce_schema: dict, test_db_url: str):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as cfg:
+            cfg.write(f"database:\n  url: {test_db_url}\n")
+            cfg.flush()
+            cfg_path = cfg.name
+
+        try:
+            result = subprocess.run(
+                [
+                    "python",
+                    "-m",
+                    "dbslice",
+                    "extract",
+                    "--config",
+                    cfg_path,
+                    "--seed",
+                    "orders.id=1",
+                    "--no-validate",
+                    "--no-progress",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+        finally:
+            os.unlink(cfg_path)
+
+    def test_cli_profile_with_config(self, ecommerce_schema: dict, test_db_url: str):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as cfg:
+            cfg.write(f"database:\n  url: {test_db_url}\n")
+            cfg.flush()
+            cfg_path = cfg.name
+
+        try:
+            result = subprocess.run(
+                [
+                    "python",
+                    "-m",
+                    "dbslice",
+                    "extract",
+                    "--config",
+                    cfg_path,
+                    "--seed",
+                    "orders.id=1",
+                    "--profile",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+            assert (
+                "QUERY PERFORMANCE PROFILE" in result.stderr
+                or "Total queries" in result.stderr
+                or "queries" in result.stderr.lower()
+            )
+        finally:
+            os.unlink(cfg_path)
+
+    def test_cli_stream_with_config(self, ecommerce_schema: dict, test_db_url: str):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as cfg:
+            cfg.write(f"database:\n  url: {test_db_url}\n")
+            cfg.flush()
+            cfg_path = cfg.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as out:
+            output_file = out.name
+
+        try:
+            result = subprocess.run(
+                [
+                    "python",
+                    "-m",
+                    "dbslice",
+                    "extract",
+                    "--config",
+                    cfg_path,
+                    "--seed",
+                    "orders.id=1",
+                    "--stream",
+                    "--out-file",
+                    output_file,
+                ],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+            assert os.path.exists(output_file)
+        finally:
+            os.unlink(cfg_path)
+            if os.path.exists(output_file):
+                os.unlink(output_file)
+
     def test_cli_stream_threshold(self, ecommerce_schema: dict, test_db_url: str):
         """Test --stream-threshold flag."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as f:
@@ -729,6 +824,8 @@ class TestCLIVersion:
 
     def test_cli_version(self):
         """Test --version flag."""
+        from importlib.metadata import version
+
         result = subprocess.run(
             [
                 "python",
@@ -742,7 +839,7 @@ class TestCLIVersion:
 
         assert result.returncode == 0
         assert "dbslice" in result.stdout
-        # Should show version number
+        assert version("dbslice") in result.stdout
 
 
 class TestCLIHelp:

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -195,6 +195,61 @@ class TestDeterministicAnonymizer:
         # Custom field also anonymized
         assert anon.should_anonymize("users", "custom_field")
 
+    def test_exact_field_provider_is_authoritative(self):
+        anon = DeterministicAnonymizer()
+        anon.configure(
+            [],
+            field_providers={"users.email": "company"},
+            patterns={"users.*": "name"},
+        )
+
+        assert anon._resolve_faker_method("users", "email") == "company"
+        assert anon.should_anonymize("users", "email")
+
+    def test_custom_pattern_provider_applies(self):
+        anon = DeterministicAnonymizer()
+        anon.configure(
+            [],
+            patterns={"users.*_email": "email"},
+        )
+
+        assert anon._resolve_faker_method("users", "backup_email") == "email"
+        assert anon.should_anonymize("users", "backup_email")
+
+    def test_custom_pattern_most_specific_wins(self):
+        anon = DeterministicAnonymizer()
+        anon.configure(
+            [],
+            patterns={
+                "users.*_email": "email",
+                "users.backup_email": "domain_name",
+            },
+        )
+
+        assert anon._resolve_faker_method("users", "backup_email") == "domain_name"
+
+    def test_custom_pattern_tie_uses_first_defined(self):
+        anon = DeterministicAnonymizer()
+        anon.configure(
+            [],
+            patterns={
+                "users.us*r_id": "name",
+                "users.u*er_id": "company",
+            },
+        )
+
+        assert anon._resolve_faker_method("users", "user_id") == "name"
+
+    def test_security_null_fields_applies(self):
+        anon = DeterministicAnonymizer()
+        anon.configure(
+            [],
+            security_null_fields=["users.secret_*", "*.api_key"],
+        )
+
+        assert anon.anonymize_value("shh", "users", "secret_note") is None
+        assert anon.anonymize_value("k123", "services", "api_key") is None
+
     def test_anonymize_row(self):
         anon = DeterministicAnonymizer()
 
@@ -279,6 +334,8 @@ class TestDeterministicAnonymizer:
         assert anon.get_faker_method("address") == "address"
         assert anon.get_faker_method("city") == "city"
         assert anon.get_faker_method("ssn") == "ssn"
+        assert anon.get_faker_method("routing_number") == "aba"
+        assert anon.get_faker_method("driver_license") == "license_plate"
         assert anon.get_faker_method("unknown_field") == "pystr"
 
     def test_anonymize_numeric_values(self):
@@ -368,6 +425,88 @@ class TestDeterministicAnonymizer:
         assert anonymized["id"] == 100
         assert anonymized["user_id"] == 1  # FK preserved!
         assert anonymized["user_email"] != "test@example.com"  # Email anonymized
+
+    def test_security_null_fields_do_not_null_foreign_keys(self):
+        users_table = Table(
+            name="users",
+            schema="public",
+            columns=[
+                Column(name="id", data_type="INTEGER", nullable=False, is_primary_key=True),
+            ],
+            primary_key=("id",),
+            foreign_keys=[],
+        )
+        orders_fk = ForeignKey(
+            name="fk_orders_user",
+            source_table="orders",
+            source_columns=("user_id",),
+            target_table="users",
+            target_columns=("id",),
+            is_nullable=False,
+        )
+        orders_table = Table(
+            name="orders",
+            schema="public",
+            columns=[
+                Column(name="id", data_type="INTEGER", nullable=False, is_primary_key=True),
+                Column(name="user_id", data_type="INTEGER", nullable=False, is_primary_key=False),
+            ],
+            primary_key=("id",),
+            foreign_keys=[orders_fk],
+        )
+        schema = SchemaGraph(
+            tables={"users": users_table, "orders": orders_table},
+            edges=[orders_fk],
+        )
+        anon = DeterministicAnonymizer(schema=schema)
+        anon.configure([], security_null_fields=["orders.user_id"])
+
+        assert anon.should_null("orders", "user_id") is False
+        assert anon.anonymize_value(1, "orders", "user_id") == 1
+
+    def test_foreign_key_detection_works_without_table_fk_population(self):
+        """FK detection should work from graph edges even if table.foreign_keys is empty."""
+        users_table = Table(
+            name="users",
+            schema="public",
+            columns=[
+                Column(name="id", data_type="INTEGER", nullable=False, is_primary_key=True),
+            ],
+            primary_key=("id",),
+            foreign_keys=[],
+        )
+
+        orders_fk = ForeignKey(
+            name="fk_orders_user",
+            source_table="orders",
+            source_columns=("user_id",),
+            target_table="users",
+            target_columns=("id",),
+            is_nullable=False,
+        )
+
+        # NOTE: foreign_keys intentionally left empty on orders_table to simulate
+        # adapter schemas before per-table FK lists are populated.
+        orders_table = Table(
+            name="orders",
+            schema="public",
+            columns=[
+                Column(name="id", data_type="INTEGER", nullable=False, is_primary_key=True),
+                Column(name="user_id", data_type="INTEGER", nullable=False, is_primary_key=False),
+                Column(name="email", data_type="VARCHAR", nullable=True, is_primary_key=False),
+            ],
+            primary_key=("id",),
+            foreign_keys=[],
+        )
+
+        schema = SchemaGraph(
+            tables={"users": users_table, "orders": orders_table},
+            edges=[orders_fk],
+        )
+        anon = DeterministicAnonymizer(schema=schema)
+
+        assert not anon.should_anonymize("orders", "user_id")
+        assert anon.should_anonymize("orders", "email")
 
     def test_column_name_in_hash(self):
         """Hash includes column name for better determinism."""

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -14,6 +14,7 @@ from dbslice.config_file import (
     DbsliceConfig,
     ExtractionConfig,
     OutputConfig,
+    PerformanceConfig,
     TableOverride,
     load_config,
 )
@@ -26,6 +27,7 @@ class TestDatabaseConfig:
         config = DatabaseConfig()
         assert config.url is None
         assert config.schema is None
+        assert config.options == {}
 
     def test_with_url(self):
         config = DatabaseConfig(url="postgres://localhost/test")
@@ -36,6 +38,13 @@ class TestDatabaseConfig:
         assert config.url == "postgres://localhost/test"
         assert config.schema == "myschema"
 
+    def test_with_options(self):
+        config = DatabaseConfig(
+            url="postgres://localhost/test",
+            options={"sslmode": "require", "connect_timeout": "10"},
+        )
+        assert config.options == {"sslmode": "require", "connect_timeout": "10"}
+
 
 class TestExtractionConfig:
     """Tests for ExtractionConfig dataclass."""
@@ -45,6 +54,8 @@ class TestExtractionConfig:
         assert config.default_depth == 3
         assert config.direction == "both"
         assert config.exclude_tables == []
+        assert config.validate is True
+        assert config.fail_on_validation_error is False
         assert config.max_rows_per_table is None
 
     def test_custom_values(self):
@@ -68,16 +79,22 @@ class TestAnonymizationConfig:
         assert config.enabled is False
         assert config.seed is None
         assert config.fields == {}
+        assert config.patterns == {}
+        assert config.security_null_fields == []
 
     def test_with_fields(self):
         config = AnonymizationConfig(
             enabled=True,
             seed="test_seed",
             fields={"users.email": "email", "users.phone": "phone_number"},
+            patterns={"users.*_email": "email"},
+            security_null_fields=["users.password*"],
         )
         assert config.enabled is True
         assert config.seed == "test_seed"
         assert config.fields == {"users.email": "email", "users.phone": "phone_number"}
+        assert config.patterns == {"users.*_email": "email"}
+        assert config.security_null_fields == ["users.password*"]
 
 
 class TestOutputConfig:
@@ -87,13 +104,23 @@ class TestOutputConfig:
         config = OutputConfig()
         assert config.format == "sql"
         assert config.include_transaction is True
-        assert config.include_drop_tables is False
+        assert config.include_truncate is False
+        assert config.disable_fk_checks is False
+        assert config.file_mode == 0o600
 
     def test_custom_values(self):
-        config = OutputConfig(format="json", include_transaction=False, include_drop_tables=True)
+        config = OutputConfig(
+            format="json",
+            include_transaction=False,
+            include_truncate=True,
+            disable_fk_checks=True,
+            file_mode=0o640,
+        )
         assert config.format == "json"
         assert config.include_transaction is False
-        assert config.include_drop_tables is True
+        assert config.include_truncate is True
+        assert config.disable_fk_checks is True
+        assert config.file_mode == 0o640
 
 
 class TestTableOverride:
@@ -102,7 +129,10 @@ class TestTableOverride:
     def test_default_values(self):
         override = TableOverride()
         assert override.skip is False
+        assert override.depth is None
+        assert override.direction is None
         assert override.max_rows is None
+        assert override.anonymize_fields == {}
 
     def test_skip_table(self):
         override = TableOverride(skip=True)
@@ -111,6 +141,16 @@ class TestTableOverride:
     def test_max_rows(self):
         override = TableOverride(max_rows=100)
         assert override.max_rows == 100
+
+    def test_legacy_fields(self):
+        override = TableOverride(
+            depth=2,
+            direction="up",
+            anonymize_fields={"email": "email"},
+        )
+        assert override.depth == 2
+        assert override.direction == "up"
+        assert override.anonymize_fields == {"email": "email"}
 
 
 class TestDbsliceConfig:
@@ -180,6 +220,9 @@ extraction:
         yaml_content = """
 database:
   url: postgres://user:pass@localhost:5432/myapp
+  options:
+    sslmode: require
+    connect_timeout: 10
 
 extraction:
   default_depth: 5
@@ -196,6 +239,12 @@ anonymization:
     users.email: email
     users.phone: phone_number
     customers.address: address
+  patterns:
+    users.*_name: name
+    "*.phone*": phone_number
+  security_null_fields:
+    - users.password*
+    - "*.api_key"
 
 output:
   format: json
@@ -207,6 +256,14 @@ tables:
     skip: true
   large_table:
     max_rows: 500
+  users:
+    depth: 2
+    direction: up
+    anonymize_fields:
+      email: email
+
+performance:
+  batch_size: 250
 """
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write(yaml_content)
@@ -218,6 +275,10 @@ tables:
 
             # Database
             assert config.database.url == "postgres://user:pass@localhost:5432/myapp"
+            assert config.database.options == {
+                "sslmode": "require",
+                "connect_timeout": "10",
+            }
 
             # Extraction
             assert config.extraction.default_depth == 5
@@ -233,17 +294,31 @@ tables:
                 "users.phone": "phone_number",
                 "customers.address": "address",
             }
+            assert config.anonymization.patterns == {
+                "users.*_name": "name",
+                "*.phone*": "phone_number",
+            }
+            assert config.anonymization.security_null_fields == [
+                "users.password*",
+                "*.api_key",
+            ]
 
             # Output
             assert config.output.format == "json"
             assert config.output.include_transaction is False
-            assert config.output.include_drop_tables is True
+            assert config.output.include_truncate is True
 
             # Tables
             assert "sessions" in config.tables
             assert config.tables["sessions"].skip is True
             assert "large_table" in config.tables
             assert config.tables["large_table"].max_rows == 500
+            assert config.tables["users"].depth == 2
+            assert config.tables["users"].direction == "up"
+            assert config.tables["users"].anonymize_fields == {"email": "email"}
+
+            # Performance
+            assert config.performance.batch_size == 250
         finally:
             Path(temp_path).unlink()
 
@@ -353,6 +428,200 @@ output:
         finally:
             Path(temp_path).unlink()
 
+    def test_from_yaml_performance_settings(self):
+        yaml_content = """
+database:
+  url: postgres://localhost/test
+performance:
+  profile: true
+  streaming:
+    enabled: true
+    threshold: 123
+    chunk_size: 7
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            config = DbsliceConfig.from_yaml(temp_path)
+            assert config.performance.profile is True
+            assert config.performance.streaming.enabled is True
+            assert config.performance.streaming.threshold == 123
+            assert config.performance.streaming.chunk_size == 7
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_invalid_database_options_type(self):
+        yaml_content = """
+database:
+  url: postgres://localhost/test
+  options:
+    - bad
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ConfigFileError) as exc_info:
+                DbsliceConfig.from_yaml(temp_path)
+            assert "database.options" in str(exc_info.value)
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_invalid_performance_batch_size(self):
+        yaml_content = """
+database:
+  url: postgres://localhost/test
+performance:
+  batch_size: 0
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ConfigFileError) as exc_info:
+                DbsliceConfig.from_yaml(temp_path)
+            assert "batch_size" in str(exc_info.value).lower()
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_legacy_table_exclude_alias(self):
+        yaml_content = """
+tables:
+  logs:
+    exclude: true
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            config = DbsliceConfig.from_yaml(temp_path)
+            assert config.tables["logs"].skip is True
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_legacy_table_exclude_conflict(self):
+        yaml_content = """
+tables:
+  logs:
+    skip: true
+    exclude: false
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ConfigFileError) as exc_info:
+                DbsliceConfig.from_yaml(temp_path)
+            assert "disagree" in str(exc_info.value).lower()
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_unknown_key_fails(self):
+        yaml_content = """
+unknown_section:
+  x: 1
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ConfigFileError) as exc_info:
+                DbsliceConfig.from_yaml(temp_path)
+            assert "unknown key" in str(exc_info.value).lower()
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_custom_anonymization_rules(self):
+        yaml_content = """
+anonymization:
+  enabled: true
+  patterns:
+    users.*_email: email
+  security_null_fields:
+    - users.password*
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            config = DbsliceConfig.from_yaml(temp_path)
+            assert config.anonymization.patterns == {"users.*_email": "email"}
+            assert config.anonymization.security_null_fields == ["users.password*"]
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_invalid_anonymization_provider_fails(self):
+        yaml_content = """
+anonymization:
+  enabled: true
+  patterns:
+    users.*_email: no_such_provider
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ConfigFileError) as exc_info:
+                DbsliceConfig.from_yaml(temp_path)
+            assert "unknown faker provider" in str(exc_info.value).lower()
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_invalid_anonymization_field_key_fails(self):
+        yaml_content = """
+anonymization:
+  enabled: true
+  fields:
+    users_*_email: email
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ConfigFileError) as exc_info:
+                DbsliceConfig.from_yaml(temp_path)
+            assert "table.column" in str(exc_info.value).lower()
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_invalid_security_null_field_pattern_fails(self):
+        yaml_content = """
+anonymization:
+  enabled: true
+  security_null_fields:
+    - password*
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ConfigFileError) as exc_info:
+                DbsliceConfig.from_yaml(temp_path)
+            assert "table.column" in str(exc_info.value).lower()
+        finally:
+            Path(temp_path).unlink()
+
 
 class TestToExtractConfig:
     """Tests for converting DbsliceConfig to ExtractConfig."""
@@ -450,6 +719,47 @@ class TestToExtractConfig:
         assert "customers.address" in extract_config.redact_fields
         assert "customers.ssn" in extract_config.redact_fields
 
+    def test_anonymization_rules_ignored_when_disabled(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            anonymization=AnonymizationConfig(
+                enabled=False,
+                fields={"users.email": "email"},
+                patterns={"users.*_name": "name"},
+                security_null_fields=["users.password*"],
+            ),
+        )
+
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(seeds=seeds)
+
+        assert extract_config.anonymize is False
+        assert extract_config.redact_fields == []
+        assert extract_config.anonymization_field_providers == {}
+        assert extract_config.anonymization_patterns == {}
+        assert extract_config.security_null_fields == []
+
+    def test_cli_redact_still_works_when_anonymization_disabled(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            anonymization=AnonymizationConfig(
+                enabled=False,
+                fields={"users.email": "email"},
+                patterns={"users.*_name": "name"},
+            ),
+        )
+
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(
+            seeds=seeds,
+            redact=["users.custom_note"],
+        )
+
+        assert extract_config.anonymize is False
+        assert extract_config.redact_fields == ["users.custom_note"]
+        assert extract_config.anonymization_field_providers == {}
+        assert extract_config.anonymization_patterns == {}
+
     def test_missing_database_url(self):
         config = DbsliceConfig()  # No database URL
         seeds = [SeedSpec.parse("users.id=1")]
@@ -490,6 +800,151 @@ class TestToExtractConfig:
         extract_config = config.to_extract_config(seeds=seeds)
         assert extract_config.schema is None
 
+    def test_row_limit_settings_propagate(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            extraction=ExtractionConfig(max_rows_per_table=1000),
+        )
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(seeds=seeds)
+        assert extract_config.row_limit_global == 1000
+
+    def test_table_row_limit_settings_propagate(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            tables={"users": TableOverride(max_rows=100)},
+        )
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(seeds=seeds)
+        assert extract_config.row_limit_per_table == {"users": 100}
+
+    def test_database_options_merged_into_url(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(
+                url="postgres://localhost/test?sslmode=disable",
+                options={"sslmode": "require", "application_name": "dbslice"},
+            ),
+        )
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(seeds=seeds)
+        assert "sslmode=require" in extract_config.database_url
+        assert "application_name=dbslice" in extract_config.database_url
+
+    def test_database_options_ignored_when_cli_url_provided(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(
+                url="postgres://localhost/test",
+                options={"sslmode": "require"},
+            ),
+        )
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(
+            seeds=seeds, database_url="postgres://localhost/override"
+        )
+        assert extract_config.database_url == "postgres://localhost/override"
+        assert "sslmode" not in extract_config.database_url
+
+    def test_performance_batch_size_propagates(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            performance=PerformanceConfig(batch_size=321),
+        )
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(seeds=seeds)
+        assert extract_config.db_batch_size == 321
+
+    def test_table_depth_and_direction_overrides_propagate(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            tables={
+                "orders": TableOverride(depth=1, direction="up"),
+                "users": TableOverride(direction="both"),
+            },
+        )
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(seeds=seeds)
+        assert extract_config.table_depth_overrides == {"orders": 1}
+        assert extract_config.table_direction_overrides == {
+            "orders": TraversalDirection.UP,
+            "users": TraversalDirection.BOTH,
+        }
+
+    def test_legacy_table_anonymize_fields_merged(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            anonymization=AnonymizationConfig(
+                enabled=True,
+                fields={"users.email": "safe_email"},
+            ),
+            tables={
+                "users": TableOverride(
+                    anonymize_fields={"email": "email", "name": "name"},
+                )
+            },
+        )
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(seeds=seeds)
+        assert extract_config.anonymization_field_providers == {
+            "users.email": "safe_email",
+            "users.name": "name",
+        }
+        assert "users.email" in extract_config.redact_fields
+        assert "users.name" in extract_config.redact_fields
+
+    def test_runtime_flags_propagate_in_to_extract_config(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            anonymization=AnonymizationConfig(
+                enabled=True,
+                seed="abc123",
+                fields={"users.email": "email"},
+                patterns={"users.*_name": "name"},
+                security_null_fields=["users.password*"],
+            ),
+            output=OutputConfig(
+                include_transaction=False,
+                include_truncate=True,
+                disable_fk_checks=True,
+                file_mode=0o640,
+            ),
+        )
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(
+            seeds=seeds,
+            validate=False,
+            fail_on_validation_error=True,
+            profile=True,
+            stream=True,
+            stream_threshold=100,
+            stream_chunk_size=5,
+            output_file_mode=0o660,
+        )
+
+        assert extract_config.validate is False
+        assert extract_config.fail_on_validation_error is True
+        assert extract_config.profile is True
+        assert extract_config.stream is True
+        assert extract_config.streaming_threshold == 100
+        assert extract_config.streaming_chunk_size == 5
+        assert extract_config.include_transaction is False
+        assert extract_config.include_truncate is True
+        assert extract_config.disable_fk_checks is True
+        assert extract_config.output_file_mode == 0o660
+        assert extract_config.anonymization_seed == "abc123"
+        assert extract_config.anonymization_field_providers == {"users.email": "email"}
+        assert extract_config.anonymization_patterns == {"users.*_name": "name"}
+        assert extract_config.security_null_fields == ["users.password*"]
+
+    def test_extraction_validation_defaults_come_from_config(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            extraction=ExtractionConfig(validate=False, fail_on_validation_error=True),
+        )
+        seeds = [SeedSpec.parse("users.id=1")]
+        extract_config = config.to_extract_config(seeds=seeds)
+        assert extract_config.validate is False
+        assert extract_config.fail_on_validation_error is True
+
 
 class TestToYaml:
     """Tests for exporting config to YAML."""
@@ -508,7 +963,12 @@ class TestToYaml:
         config = DbsliceConfig(
             database=DatabaseConfig(url="postgres://localhost/test"),
             extraction=ExtractionConfig(default_depth=5, direction="up", exclude_tables=["logs"]),
-            anonymization=AnonymizationConfig(enabled=True, fields={"users.email": "email"}),
+            anonymization=AnonymizationConfig(
+                enabled=True,
+                fields={"users.email": "email"},
+                patterns={"users.*_email": "email"},
+                security_null_fields=["users.password*"],
+            ),
             output=OutputConfig(format="json", include_transaction=False),
             tables={"sessions": TableOverride(skip=True)},
         )
@@ -521,7 +981,10 @@ class TestToYaml:
         assert data["extraction"]["default_depth"] == 5
         assert data["extraction"]["direction"] == "up"
         assert data["anonymization"]["enabled"] is True
+        assert data["anonymization"]["patterns"]["users.*_email"] == "email"
+        assert data["anonymization"]["security_null_fields"] == ["users.password*"]
         assert data["output"]["format"] == "json"
+        assert data["output"]["include_truncate"] is False
         assert data["tables"]["sessions"]["skip"] is True
 
     def test_yaml_with_schema(self):
@@ -541,6 +1004,20 @@ class TestToYaml:
         assert "# Database connection settings" in yaml_str
         assert "# Extraction behavior" in yaml_str
         assert "# schema: public" in yaml_str
+
+    def test_yaml_roundtrip_with_leading_wildcards(self):
+        config = DbsliceConfig(
+            database=DatabaseConfig(url="postgres://localhost/test"),
+            anonymization=AnonymizationConfig(
+                enabled=True,
+                patterns={"*.api_key": "pystr"},
+                security_null_fields=["*.token"],
+            ),
+        )
+        yaml_str = config.to_yaml(include_comments=False)
+        data = yaml.safe_load(yaml_str)
+        assert data["anonymization"]["patterns"]["*.api_key"] == "pystr"
+        assert data["anonymization"]["security_null_fields"] == ["*.token"]
 
 
 class TestLoadConfig:
@@ -574,7 +1051,12 @@ class TestConfigFileRoundtrip:
         original = DbsliceConfig(
             database=DatabaseConfig(url="postgres://localhost/test"),
             extraction=ExtractionConfig(default_depth=5, direction="up"),
-            anonymization=AnonymizationConfig(enabled=True, fields={"users.email": "email"}),
+            anonymization=AnonymizationConfig(
+                enabled=True,
+                fields={"users.email": "email"},
+                patterns={"users.*_email": "email"},
+                security_null_fields=["users.password*"],
+            ),
             output=OutputConfig(format="json"),
             tables={"logs": TableOverride(skip=True)},
         )
@@ -596,6 +1078,11 @@ class TestConfigFileRoundtrip:
             assert loaded.extraction.direction == original.extraction.direction
             assert loaded.anonymization.enabled == original.anonymization.enabled
             assert loaded.anonymization.fields == original.anonymization.fields
+            assert loaded.anonymization.patterns == original.anonymization.patterns
+            assert (
+                loaded.anonymization.security_null_fields
+                == original.anonymization.security_null_fields
+            )
             assert loaded.output.format == original.output.format
             assert "logs" in loaded.tables
             assert loaded.tables["logs"].skip is True

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -121,6 +121,38 @@ class TestGraphTraverser:
         # UP traversal is not depth-limited, so users should be found
         assert "users" in result.records
 
+    def test_table_direction_override_blocks_downward_traversal(self, sample_schema, mock_adapter):
+        """Per-table direction override should block queued directions for that table."""
+        traverser = GraphTraverser(sample_schema, mock_adapter)
+        config = TraversalConfig(
+            max_depth=3,
+            direction=TraversalDirection.BOTH,
+            table_direction_overrides={"orders": TraversalDirection.UP},
+        )
+
+        result = traverser.traverse("orders", {(1,)}, config)
+
+        # Parent traversal still allowed
+        assert "users" in result.records
+        # Downward traversal from orders should be blocked
+        assert "order_items" not in result.records
+
+    def test_table_depth_override_limits_downward_from_table(self, sample_schema, mock_adapter):
+        """Per-table depth override should cap DOWN traversal when that table is current."""
+        traverser = GraphTraverser(sample_schema, mock_adapter)
+        config = TraversalConfig(
+            max_depth=5,
+            direction=TraversalDirection.DOWN,
+            table_depth_overrides={"orders": 1},
+        )
+
+        result = traverser.traverse("users", {(1,)}, config)
+
+        # users -> orders should still occur
+        assert "orders" in result.records
+        # orders -> order_items should be blocked by per-table depth cap
+        assert "order_items" not in result.records
+
     def test_exclude_tables(self, sample_schema, mock_adapter):
         """Excluded tables should be skipped."""
         traverser = GraphTraverser(sample_schema, mock_adapter)
@@ -175,13 +207,19 @@ class TestTraversalConfig:
         assert config.max_depth == 3
         assert config.direction == TraversalDirection.BOTH
         assert config.exclude_tables == set()
+        assert config.table_depth_overrides == {}
+        assert config.table_direction_overrides == {}
 
     def test_custom_values(self):
         config = TraversalConfig(
             max_depth=5,
             direction=TraversalDirection.UP,
             exclude_tables={"audit_logs"},
+            table_depth_overrides={"orders": 1},
+            table_direction_overrides={"orders": TraversalDirection.UP},
         )
         assert config.max_depth == 5
         assert config.direction == TraversalDirection.UP
         assert "audit_logs" in config.exclude_tables
+        assert config.table_depth_overrides == {"orders": 1}
+        assert config.table_direction_overrides == {"orders": TraversalDirection.UP}

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,22 +1,22 @@
 """Performance tests for query batching and profiling."""
 
+from contextlib import contextmanager
+
 import pytest
 
 from dbslice.adapters.postgresql import PostgreSQLAdapter
+from dbslice.config import ExtractConfig, SeedSpec
+from dbslice.core.engine import ExtractionEngine
 from dbslice.utils.profiling import QueryProfiler
 
 
 def test_fetch_fk_values_batching(sample_schema, mock_adapter):
-    """Test that fetch_fk_values uses batching for large PK sets."""
-    # Create a PostgreSQL adapter with small batch size for testing
+    """Test effective batch sizing for FK lookups with different key widths."""
     adapter = PostgreSQLAdapter(batch_size=10, profiler=None)
-    adapter._conn = None  # Mock connection
-    adapter._schema_cache = sample_schema
-
-    # We can't easily test the batching without a real database connection,
-    # but we can verify the batching logic is in place by checking the code path
-    # This is more of an integration test placeholder
-    assert adapter.batch_size == 10
+    assert adapter._effective_batch_size(1) == 10
+    assert adapter._effective_batch_size(2) == 5
+    assert adapter._effective_batch_size(4) == 2
+    assert adapter._effective_batch_size(20) == 1
 
 
 def test_query_profiler_tracks_queries():
@@ -197,15 +197,17 @@ def test_query_profiler_reset():
 
 
 def test_batch_size_calculation():
-    """Test that batch size is calculated correctly for composite keys."""
+    """Test effective batch sizing and chunk splitting behavior."""
     adapter = PostgreSQLAdapter(batch_size=1000)
+    assert adapter._effective_batch_size(1) == 1000
+    assert adapter._effective_batch_size(2) == 500
+    assert adapter._effective_batch_size(4) == 250
 
-    # For single-column PK, effective batch size should be 1000
-    # For 2-column PK, effective batch size should be 500
-    # For 4-column PK, effective batch size should be 250
-
-    # We can verify this logic by checking the batch_size attribute
-    assert adapter.batch_size == 1000
+    pk_values = [(i,) for i in range(1200)]
+    batches = list(adapter._iter_pk_batches(pk_values, params_per_row=1))
+    assert len(batches) == 2
+    assert len(batches[0][1]) == 1000
+    assert len(batches[1][1]) == 200
 
 
 def test_profiler_integration_with_adapter():
@@ -216,6 +218,42 @@ def test_profiler_integration_with_adapter():
     # Verify profiler is attached
     assert adapter.profiler is profiler
     assert adapter.batch_size == 100
+
+
+def test_engine_passes_configured_batch_size_to_adapter(monkeypatch):
+    """ExtractionEngine should forward db_batch_size to PostgreSQLAdapter."""
+    captured: dict[str, int | None] = {}
+
+    class FakePostgreSQLAdapter:
+        def __init__(self, batch_size=None, profiler=None, schema=None):
+            captured["batch_size"] = batch_size
+
+        def connect(self, url: str) -> None:
+            raise RuntimeError("stop after adapter init")
+
+        def close(self) -> None:
+            return None
+
+        @contextmanager
+        def snapshot_transaction(self):
+            yield
+
+    monkeypatch.setattr(
+        "dbslice.adapters.postgresql.PostgreSQLAdapter",
+        FakePostgreSQLAdapter,
+    )
+
+    config = ExtractConfig(
+        database_url="postgresql://localhost/test",
+        seeds=[SeedSpec.parse("users.id=1")],
+        db_batch_size=777,
+    )
+
+    engine = ExtractionEngine(config)
+    with pytest.raises(RuntimeError, match="stop after adapter init"):
+        engine.extract()
+
+    assert captured["batch_size"] == 777
 
 
 def test_performance_improvement_with_batching(sample_schema, mock_adapter):
@@ -232,24 +270,14 @@ def test_performance_improvement_with_batching(sample_schema, mock_adapter):
     With batching (batch_size=100):
     - 1000 orders would result in 10 queries
     """
-    # This would be tested with an actual database in integration tests
-    # Here we're just documenting the expected behavior
+    adapter = PostgreSQLAdapter(batch_size=100, profiler=None)
+    pk_values = [(i,) for i in range(1000)]
+    batches = list(adapter._iter_pk_batches(pk_values, params_per_row=1))
 
-    num_orders = 1000
-    batch_size = 100
-
-    # Expected queries without batching
-    queries_without_batching = num_orders
-
-    # Expected queries with batching
-    queries_with_batching = (num_orders + batch_size - 1) // batch_size  # Ceiling division
-
-    assert queries_with_batching == 10
-    assert queries_with_batching < queries_without_batching
-
-    # Performance improvement ratio
-    improvement_ratio = queries_without_batching / queries_with_batching
-    assert improvement_ratio == 100  # 100x fewer queries
+    # One-by-one would require 1000 queries.
+    # Batching with size 100 requires only 10 query batches.
+    assert len(batches) == 10
+    assert len(batches) < 1000
 
 
 def test_mock_adapter_fk_fetching(sample_schema, mock_adapter):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -408,9 +408,8 @@ class TestOutputFileSecurity:
         """Output to system directories should be rejected."""
         from dbslice.input_validators import FilePathValidationError, validate_output_file_path
 
-        # /bin and /usr/bin are reliably blocked on all platforms
-        # /etc may resolve to /private/etc on macOS, bypassing the check (documented finding)
-        system_paths = ["/bin/output.sql", "/usr/bin/output.sql", "/sbin/output.sql"]
+        # Canonical system paths should be blocked.
+        system_paths = ["/bin/output.sql", "/usr/bin/output.sql", "/sbin/output.sql", "/etc/output.sql"]
         for path in system_paths:
             with pytest.raises(FilePathValidationError):
                 validate_output_file_path(path)
@@ -422,25 +421,18 @@ class TestOutputFileSecurity:
         with pytest.raises(FilePathValidationError):
             validate_output_file_path("")
 
-    def test_output_file_world_readable_default(self):
-        """Document that output files use default permissions (0644 = world-readable).
+    def test_output_file_not_world_readable_by_default(self):
+        """Output helper should create non-world-readable files by default."""
+        from dbslice.utils.fileio import write_text_file_secure
 
-        This is an informational finding: files created by Path.write_text()
-        and open(..., 'w') use the process umask, which typically results in
-        0644 permissions. For sensitive data exports, this could be a risk.
-        """
-        # This test documents the current behavior, not a fix
         with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as f:
-            f.write("-- test output\n")
             tmpfile = f.name
 
         try:
-            mode = os.stat(tmpfile).st_mode
-            # Check if world-readable (others have read permission)
-            is_world_readable = bool(mode & stat.S_IROTH)
-            # This documents the current state -- files are world-readable by default
-            # A fix would use os.umask(0o077) or os.open with mode 0o600
-            assert isinstance(is_world_readable, bool)  # Just document, don't fail
+            write_text_file_secure(tmpfile, "-- test output\n", file_mode=0o600)
+            mode = stat.S_IMODE(os.stat(tmpfile).st_mode)
+            assert not bool(mode & stat.S_IROTH)
+            assert not bool(mode & stat.S_IWOTH)
         finally:
             os.unlink(tmpfile)
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,5 +1,7 @@
 """Tests for streaming extraction functionality."""
 
+import os
+import stat
 from typing import Any
 
 from dbslice.config import (
@@ -168,6 +170,38 @@ def test_streaming_engine_basic(sample_schema, tmp_path):
     assert len(adapter.chunked_fetch_calls) == 2  # users + orders
 
 
+def test_streaming_output_file_mode_applied(sample_schema, tmp_path):
+    """Streaming output file should honor configured file mode."""
+    data = {
+        "users": [{"id": 1, "email": "alice@example.com", "name": "Alice"}],
+    }
+    adapter = ChunkedMockAdapter(sample_schema, data)
+    adapter.connect("test://localhost/test")
+
+    config = ExtractConfig(
+        database_url="test://localhost/test",
+        seeds=[SeedSpec.parse("users.id=1")],
+        output_file_mode=0o600,
+    )
+    output_file = tmp_path / "secure_stream.sql"
+
+    engine = StreamingExtractionEngine(
+        config=config,
+        adapter=adapter,
+        schema=sample_schema,
+        records={"users": {(1,)}},
+        insert_order=["users"],
+        broken_fks=[],
+        deferred_updates=[],
+        db_type=DatabaseType.POSTGRESQL,
+        chunk_size=1,
+    )
+    engine.stream_to_file(str(output_file))
+
+    mode = stat.S_IMODE(os.stat(output_file).st_mode)
+    assert not bool(mode & stat.S_IROTH)
+
+
 def test_streaming_with_anonymization(sample_schema, tmp_path):
     """Test streaming with anonymization enabled."""
     data = {
@@ -253,6 +287,48 @@ def test_streaming_mode_forced(sample_schema):
     engine = ExtractionEngine(config)
     # Should use streaming even for small datasets
     assert engine._should_use_streaming(100)
+
+
+def test_streaming_disabled_when_row_limits_configured():
+    """Row limiting requires in-memory closure, so streaming must be disabled."""
+    config = ExtractConfig(
+        database_url="test://localhost/test",
+        seeds=[SeedSpec.parse("users.id=1")],
+        stream=True,
+        output_file="/tmp/test.sql",
+        row_limit_global=10,
+    )
+
+    engine = ExtractionEngine(config)
+    assert not engine._should_use_streaming(100000)
+
+
+def test_row_limit_soft_cap_adds_required_parents(sample_schema):
+    """Configured caps are soft: parent rows are added to preserve FK integrity."""
+    config = ExtractConfig(
+        database_url="test://localhost/test",
+        seeds=[SeedSpec.parse("orders.id=1")],
+        row_limit_per_table={"users": 1},
+    )
+    engine = ExtractionEngine(config)
+    engine.schema = sample_schema
+
+    tables_data = {
+        "users": [
+            {"id": 1, "email": "alice@example.com", "name": "Alice"},
+            {"id": 2, "email": "bob@example.com", "name": "Bob"},
+        ],
+        "orders": [
+            {"id": 1, "user_id": 1, "total": 10.0, "status": "ok"},
+            {"id": 2, "user_id": 2, "total": 20.0, "status": "ok"},
+        ],
+    }
+
+    limited = engine._apply_row_limits(tables_data)
+
+    # Initial limit would pick one user, but closure should pull in both referenced users.
+    assert len(limited["users"]) == 2
+    assert {row["id"] for row in limited["users"]} == {1, 2}
 
 
 def test_streaming_vs_inmemory_same_output(sample_schema, tmp_path):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -14,6 +14,7 @@ from dbslice.input_validators import (
     validate_depth,
     validate_exclude_tables,
     validate_identifier,
+    validate_output_file_mode,
     validate_output_file_path,
     validate_redact_fields,
     validate_seed_value,
@@ -314,6 +315,36 @@ class TestFilePathValidation:
         if os.path.exists("/bin"):
             with pytest.raises(FilePathValidationError, match="system directory"):
                 validate_output_file_path("/bin/output.sql")
+        if os.path.exists("/etc"):
+            with pytest.raises(FilePathValidationError, match="system directory"):
+                validate_output_file_path("/etc/output.sql")
+
+    def test_symlink_to_system_directory_rejected(self, tmp_path):
+        import os
+
+        if not os.path.exists("/etc"):
+            pytest.skip("/etc not available on this platform")
+
+        symlink_dir = tmp_path / "etc_link"
+        os.symlink("/etc", symlink_dir)
+
+        with pytest.raises(FilePathValidationError, match="system directory"):
+            validate_output_file_path(symlink_dir / "output.sql")
+
+
+class TestOutputFileModeValidation:
+    """Tests for output file mode validation."""
+
+    def test_valid_modes(self):
+        assert validate_output_file_mode("600") == 0o600
+        assert validate_output_file_mode("0o640") == 0o640
+        assert validate_output_file_mode(0o660) == 0o660
+
+    def test_invalid_mode(self):
+        with pytest.raises(ValidationError):
+            validate_output_file_mode("999")
+        with pytest.raises(ValidationError):
+            validate_output_file_mode("abc")
 
 
 class TestExcludeTablesValidation:


### PR DESCRIPTION
- Config file support: full YAML config parsing with CLI override precedence, per-table overrides (skip, depth, direction, max_rows), and deprecated key aliases (include_drop_tables -> include_truncate)
- Wildcard anonymization: glob-based patterns for table.column matching with exact > wildcard > builtin precedence, custom field providers, and security_null_fields wildcards
- Secure file I/O: new fileio.py with os.open/fchmod for deterministic permissions, --output-file-mode CLI flag, applied to all output paths
- Row limits: max_rows_per_table with deterministic PK-sorted selection and parent closure to preserve FK integrity
- Per-table traversal: table-specific depth and direction overrides in BFS graph traversal
- CLI: all boolean flags support --no-* variants, proper None defaults for config merging, dynamic version from package metadata
- PostgreSQL adapter: sync per-table FK lists with graph edges, simplify batch fetching
- Docs and tests updated for all new features