### PR TITLE
feat: add env-driven config/CLI precedence and PK-less safety guards

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -38,14 +38,14 @@ Extract a database subset starting from seed record(s).
 #### Synopsis
 
 ```bash
-dbslice extract [OPTIONS] DATABASE_URL
+dbslice extract [OPTIONS] [DATABASE_URL]
 ```
 
 #### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `DATABASE_URL` | Database connection URL (e.g., `postgresql://user:pass@host:5432/dbname`) |
+| `DATABASE_URL` | Optional database connection URL. If omitted, `DATABASE_URL` environment variable is used. |
 
 #### Options
 
@@ -342,14 +342,14 @@ Generate a configuration file from database schema.
 #### Synopsis
 
 ```bash
-dbslice init [OPTIONS] DATABASE_URL
+dbslice init [OPTIONS] [DATABASE_URL]
 ```
 
 #### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `DATABASE_URL` | Database connection URL |
+| `DATABASE_URL` | Optional database connection URL. If omitted, `DATABASE_URL` environment variable is used. |
 
 #### Options
 
@@ -423,14 +423,14 @@ Inspect database schema without extracting data.
 #### Synopsis
 
 ```bash
-dbslice inspect [OPTIONS] DATABASE_URL
+dbslice inspect [OPTIONS] [DATABASE_URL]
 ```
 
 #### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `DATABASE_URL` | Database connection URL |
+| `DATABASE_URL` | Optional database connection URL. If omitted, `DATABASE_URL` environment variable is used. |
 
 #### Options
 
@@ -536,6 +536,10 @@ dbslice inspect --help
 
 dbslice supports the following environment variables:
 
+Precedence for `extract` runtime settings:
+- `CLI > Env > Config`
+- For database URL specifically: CLI positional argument wins, then `DATABASE_URL`, then `database.url` from config.
+
 ### Database Connection
 
 | Variable | Description | Example |
@@ -555,12 +559,21 @@ dbslice supports the following environment variables:
 | `DBSLICE_DIRECTION` | Default traversal direction | `both` |
 | `DBSLICE_OUTPUT_FORMAT` | Default output format | `sql` |
 
+Accepted formats:
+- `DBSLICE_DEPTH`: positive integer.
+- `DBSLICE_DIRECTION`: `up`, `down`, or `both` (case-insensitive).
+- `DBSLICE_OUTPUT_FORMAT`: `sql`, `json`, or `csv` (case-insensitive).
+
 ### Security
 
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `DBSLICE_ANONYMIZE` | Enable anonymization | `true` |
 | `DBSLICE_REDACT_FIELDS` | Comma-separated redact fields | `users.ssn,payments.card` |
+
+Accepted formats:
+- `DBSLICE_ANONYMIZE`: `1/0`, `true/false`, `yes/no`, or `on/off` (case-insensitive).
+- `DBSLICE_REDACT_FIELDS`: comma-separated `table.column` values.
 
 ### Examples
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -141,6 +141,13 @@ database:
   url: ${DATABASE_URL_FILE}
 ```
 
+`database.url` placeholder behavior:
+- Exact-match placeholders only: the full value must be `${VAR}` or `${VAR_FILE}`.
+- `${VAR}`: uses the value of environment variable `VAR`.
+- `${VAR_FILE}`: reads file path from environment variable `VAR_FILE`, then uses trimmed file contents.
+- Missing env var or unreadable `_FILE` target causes config-load validation failure.
+- Partial-string interpolation is not supported.
+
 `database.options` precedence:
 - Applied only when URL comes from config (`database.url`).
 - If CLI provides database URL, config `database.options` are ignored.

--- a/src/dbslice/adapters/postgresql.py
+++ b/src/dbslice/adapters/postgresql.py
@@ -341,6 +341,9 @@ class PostgreSQLAdapter(DatabaseAdapter):
         """Fetch rows by primary key values with batching for large sets."""
         if not pk_values:
             return
+        if not pk_columns:
+            logger.warning("Skipping fetch_by_pk for table without primary key", table=table)
+            return
 
         pk_values_list = list(pk_values)
 
@@ -411,6 +414,9 @@ class PostgreSQLAdapter(DatabaseAdapter):
         """
         if not pk_values:
             return
+        if not pk_columns:
+            logger.warning("Skipping fetch_by_pk_chunked for table without primary key", table=table)
+            return
 
         pk_values_list = list(pk_values)
 
@@ -475,6 +481,13 @@ class PostgreSQLAdapter(DatabaseAdapter):
 
         pk_cols = source_table.primary_key
         fk_cols = fk.source_columns
+        if not pk_cols:
+            logger.warning(
+                "Skipping FK lookup from table without primary key",
+                table=table,
+                fk=fk.name,
+            )
+            return set()
 
         result: set[tuple[Any, ...]] = set()
         pk_values_list = list(source_pk_values)

--- a/src/dbslice/cli.py
+++ b/src/dbslice/cli.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Annotated
 
@@ -98,6 +99,88 @@ def create_progress_callback(status: Status | None, verbose: bool, console: Cons
                 console.print(f"  [dim]{message}[/dim]")
 
     return callback
+
+
+def _parse_env_database_url(var_name: str) -> str | None:
+    """Parse a database URL from environment variable."""
+    raw = os.environ.get(var_name)
+    if raw is None:
+        return None
+
+    value = raw.strip()
+    if not value:
+        raise ValueError(f"Environment variable {var_name} is set but empty")
+    return value
+
+
+def _parse_env_int(var_name: str, *, minimum: int = 1) -> int | None:
+    """Parse an integer from environment variable."""
+    raw = os.environ.get(var_name)
+    if raw is None:
+        return None
+
+    value_raw = raw.strip()
+    if not value_raw:
+        raise ValueError(f"Environment variable {var_name} must be an integer")
+
+    try:
+        value = int(value_raw)
+    except ValueError as e:
+        raise ValueError(f"Environment variable {var_name} must be an integer") from e
+
+    if value < minimum:
+        raise ValueError(f"Environment variable {var_name} must be >= {minimum}")
+    return value
+
+
+def _parse_env_choice(var_name: str, allowed: set[str]) -> str | None:
+    """Parse a case-insensitive choice from environment variable."""
+    raw = os.environ.get(var_name)
+    if raw is None:
+        return None
+
+    value = raw.strip().lower()
+    if value not in allowed:
+        raise ValueError(
+            f"Environment variable {var_name} must be one of: {', '.join(sorted(allowed))}"
+        )
+    return value
+
+
+def _parse_env_bool(var_name: str) -> bool | None:
+    """Parse a boolean from environment variable."""
+    raw = os.environ.get(var_name)
+    if raw is None:
+        return None
+
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+
+    raise ValueError(
+        f"Environment variable {var_name} must be a boolean "
+        "(accepted: 1/0, true/false, yes/no, on/off)"
+    )
+
+
+def _parse_env_comma_list(var_name: str) -> list[str] | None:
+    """Parse a comma-separated list from environment variable."""
+    raw = os.environ.get(var_name)
+    if raw is None:
+        return None
+
+    value = raw.strip()
+    if not value:
+        return []
+
+    items = [item.strip() for item in value.split(",")]
+    if any(not item for item in items):
+        raise ValueError(
+            f"Environment variable {var_name} must be a comma-separated list without empty entries"
+        )
+    return items
 
 
 def _parse_and_validate_seeds(
@@ -922,11 +1005,42 @@ def extract(
     try:
         setup_logging(verbose=verbose, no_progress=no_progress, structured=False)
         logger.debug("CLI command invoked", command="extract", depth=depth, direction=direction)
-        database_url_from_cli = database_url is not None
+        try:
+            database_url_override = database_url
+            if database_url_override is None:
+                database_url_override = _parse_env_database_url("DATABASE_URL")
+            database_url_from_override = database_url_override is not None
 
-        effective_depth = depth if depth is not None else DEFAULT_TRAVERSAL_DEPTH
-        effective_direction = direction if direction is not None else "both"
-        effective_output = output if output is not None else "sql"
+            depth_override = depth
+            if depth_override is None:
+                depth_override = _parse_env_int("DBSLICE_DEPTH", minimum=1)
+
+            direction_override = direction
+            if direction_override is None:
+                direction_override = _parse_env_choice(
+                    "DBSLICE_DIRECTION", {"up", "down", "both"}
+                )
+
+            output_override = output
+            if output_override is None:
+                output_override = _parse_env_choice(
+                    "DBSLICE_OUTPUT_FORMAT", {"sql", "json", "csv"}
+                )
+
+            anonymize_override = anonymize
+            if anonymize_override is None:
+                anonymize_override = _parse_env_bool("DBSLICE_ANONYMIZE")
+
+            redact_override = redact
+            if redact_override is None:
+                redact_override = _parse_env_comma_list("DBSLICE_REDACT_FIELDS")
+        except ValueError as e:
+            console.print(f"[red]Validation Error:[/red] {e}")
+            raise typer.Exit(1)
+
+        effective_depth = depth_override if depth_override is not None else DEFAULT_TRAVERSAL_DEPTH
+        effective_direction = direction_override if direction_override is not None else "both"
+        effective_output = output_override if output_override is not None else "sql"
         effective_validate = validate if validate is not None else True
         effective_fail_on_validation_error = (
             fail_on_validation_error if fail_on_validation_error is not None else False
@@ -954,17 +1068,19 @@ def extract(
                 console.print(f"[red]Config Error:[/red] {e}")
                 raise typer.Exit(1)
 
-        if not database_url and (not loaded_config or not loaded_config.database.url):
+        if not database_url_override and (not loaded_config or not loaded_config.database.url):
             console.print(
                 "[red]Error:[/red] Database URL is required. "
-                "Provide it via DATABASE_URL argument or in config file under 'database.url'"
+                "Provide it via DATABASE_URL argument, DATABASE_URL environment variable, "
+                "or in config file under 'database.url'"
             )
             raise typer.Exit(1)
 
-        if not database_url and loaded_config:
-            database_url = loaded_config.database.url
+        resolved_database_url = database_url_override
+        if not resolved_database_url and loaded_config:
+            resolved_database_url = loaded_config.database.url
 
-        assert database_url is not None  # Guaranteed by the check above
+        assert resolved_database_url is not None  # Guaranteed by the check above
 
         effective_json_mode = json_mode if json_mode is not None else "auto"
         effective_json_pretty = json_pretty if json_pretty is not None else True
@@ -982,7 +1098,7 @@ def extract(
                 effective_csv_delimiter = loaded_config.output.csv_delimiter
 
         try:
-            validate_database_url(database_url)
+            validate_database_url(resolved_database_url)
             validate_depth(effective_depth)
             if out_file:
                 validate_output_file_path(out_file)
@@ -992,11 +1108,14 @@ def extract(
                 validate_exclude_tables(exclude)
             if passthrough:
                 validate_exclude_tables(passthrough)  # Same validation as exclude
-            if redact:
-                validate_redact_fields(redact)
-            if direction is not None and direction.lower() not in {"up", "down", "both"}:
+            if redact_override:
+                validate_redact_fields(redact_override)
+            if (
+                direction_override is not None
+                and direction_override.lower() not in {"up", "down", "both"}
+            ):
                 raise ValueError("Invalid direction. Use: up, down, both")
-            if output is not None and output.lower() not in {"sql", "json", "csv"}:
+            if output_override is not None and output_override.lower() not in {"sql", "json", "csv"}:
                 raise ValueError("Invalid output format. Use: sql, json, csv")
             if effective_json_mode not in ("auto", "single", "per-table"):
                 raise ValueError(
@@ -1023,23 +1142,27 @@ def extract(
 
         if loaded_config:
             direction_enum = (
-                TraversalDirection(effective_direction.lower()) if direction is not None else None
+                TraversalDirection(effective_direction.lower())
+                if direction_override is not None
+                else None
             )
             output_format_enum = (
-                OutputFormat(effective_output.lower()) if output is not None else None
+                OutputFormat(effective_output.lower())
+                if output_override is not None
+                else None
             )
 
             extract_config = loaded_config.to_extract_config(
                 seeds=seed_specs,
-                database_url=database_url if database_url_from_cli else None,
-                depth=depth,
+                database_url=database_url_override if database_url_from_override else None,
+                depth=depth_override,
                 direction=direction_enum,
                 output_format=output_format_enum,
                 output_file=str(out_file) if out_file else None,
                 exclude=exclude,
                 passthrough=passthrough,
-                anonymize=anonymize,
-                redact=redact,
+                anonymize=anonymize_override,
+                redact=redact_override,
                 verbose=verbose,
                 dry_run=dry_run,
                 no_progress=no_progress,
@@ -1060,7 +1183,7 @@ def extract(
                 effective_direction, effective_output, console
             )
             extract_config = _build_extract_config(
-                database_url=database_url,
+                database_url=resolved_database_url,
                 seeds=seed_specs,
                 depth=effective_depth,
                 direction=direction_enum,
@@ -1068,8 +1191,8 @@ def extract(
                 out_file=out_file,
                 exclude=exclude,
                 passthrough=passthrough,
-                anonymize=bool(anonymize) if anonymize is not None else False,
-                redact=redact,
+                anonymize=bool(anonymize_override) if anonymize_override is not None else False,
+                redact=redact_override,
                 verbose=verbose,
                 dry_run=dry_run,
                 no_progress=no_progress,
@@ -1157,11 +1280,11 @@ def extract(
 @app.command()
 def init(
     database_url: Annotated[
-        str,
+        str | None,
         typer.Argument(
             help="Database connection URL (e.g., postgres://user:pass@host:5432/dbname)"
         ),
-    ],
+    ] = None,
     out_file: Annotated[
         Path,
         typer.Option(
@@ -1203,10 +1326,21 @@ def init(
         dbslice init postgres://localhost/myapp --no-detect-sensitive
     """
     try:
+        resolved_database_url = database_url
+        if resolved_database_url is None:
+            resolved_database_url = _parse_env_database_url("DATABASE_URL")
+        if not resolved_database_url:
+            console.print(
+                "[red]Error:[/red] Database URL is required. "
+                "Provide DATABASE_URL argument or set DATABASE_URL environment variable"
+            )
+            raise typer.Exit(1)
+        database_url = resolved_database_url
+
         try:
             validate_database_url(database_url)
             validate_output_file_path(out_file)
-        except ValidationError as e:
+        except (ValidationError, ValueError) as e:
             console.print(f"[red]Validation Error:[/red] {e}")
             raise typer.Exit(1)
 
@@ -1282,6 +1416,10 @@ def init(
 
         finally:
             adapter.close()
+
+    except ValueError as e:
+        console.print(f"[red]Validation Error:[/red] {e}")
+        raise typer.Exit(1)
 
     except ConnectionError as e:
         console.print(f"[red]Connection failed:[/red] {e.reason}")
@@ -1363,9 +1501,9 @@ def _detect_sensitive_fields(schema) -> dict[str, str]:
 @app.command()
 def inspect(
     database_url: Annotated[
-        str,
+        str | None,
         typer.Argument(help="Database connection URL"),
-    ],
+    ] = None,
     table: Annotated[
         str | None,
         typer.Option(
@@ -1388,13 +1526,24 @@ def inspect(
     Shows tables, foreign keys, and detected sensitive fields.
     """
     try:
+        resolved_database_url = database_url
+        if resolved_database_url is None:
+            resolved_database_url = _parse_env_database_url("DATABASE_URL")
+        if not resolved_database_url:
+            console.print(
+                "[red]Error:[/red] Database URL is required. "
+                "Provide DATABASE_URL argument or set DATABASE_URL environment variable"
+            )
+            raise typer.Exit(1)
+        database_url = resolved_database_url
+
         try:
             validate_database_url(database_url)
             if table:
                 from dbslice.input_validators import validate_table_name
 
                 validate_table_name(table)
-        except ValidationError as e:
+        except (ValidationError, ValueError) as e:
             console.print(f"[red]Validation Error:[/red] {e}")
             raise typer.Exit(1)
 
@@ -1469,6 +1618,10 @@ def inspect(
 
         finally:
             adapter.close()
+
+    except ValueError as e:
+        console.print(f"[red]Validation Error:[/red] {e}")
+        raise typer.Exit(1)
 
     except ConnectionError as e:
         console.print(f"[red]Connection failed:[/red] {e.reason}")

--- a/src/dbslice/config_file.py
+++ b/src/dbslice/config_file.py
@@ -1,4 +1,6 @@
 import inspect
+import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -70,6 +72,7 @@ _VIRTUAL_FK_KEYS = {
     "name",
     "is_nullable",
 }
+_DATABASE_URL_ENV_PATTERN = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$")
 
 
 def _validate_unknown_keys(section_name: str, data: dict[str, Any], allowed: set[str]) -> None:
@@ -165,6 +168,37 @@ def _merge_database_url_options(url: str, options: dict[str, str]) -> str:
         existing[key] = [value]
     merged_query = urlencode(existing, doseq=True)
     return urlunparse(parsed._replace(query=merged_query))
+
+
+def _resolve_database_url(raw_url: Any) -> str | None:
+    """Resolve database.url, supporting exact-match ${VAR} and ${VAR_FILE} placeholders."""
+    if raw_url is None:
+        return None
+    if not isinstance(raw_url, str):
+        raise ValueError("'database.url' must be a string")
+
+    match = _DATABASE_URL_ENV_PATTERN.fullmatch(raw_url)
+    if not match:
+        return raw_url
+
+    env_key = match.group(1)
+    env_value = os.environ.get(env_key)
+    if env_value is None:
+        raise ValueError(
+            f"'database.url' references environment variable '{env_key}', but it is not set"
+        )
+
+    if env_key.endswith("_FILE"):
+        file_path = env_value
+        try:
+            resolved = Path(file_path).read_text(encoding="utf-8")
+        except OSError as e:
+            raise ValueError(
+                f"'database.url' references '{env_key}' -> '{file_path}', but file could not be read: {e}"
+            ) from e
+        return resolved.strip()
+
+    return env_value
 
 
 def _mask_url_password(url: str) -> str:
@@ -470,9 +504,10 @@ class DbsliceConfig:
         _validate_unknown_keys("database", database_data, _DATABASE_KEYS)
 
         database_options = _normalize_database_options(database_data.get("options"))
+        database_url = _resolve_database_url(database_data.get("url"))
 
         database = DatabaseConfig(
-            url=database_data.get("url"),
+            url=database_url,
             schema=database_data.get("schema"),
             options=database_options,
         )

--- a/src/dbslice/core/engine.py
+++ b/src/dbslice/core/engine.py
@@ -14,6 +14,7 @@ from dbslice.config import (
 from dbslice.constants import DEFAULT_ANONYMIZATION_SEED, DEFAULT_TRAVERSAL_DEPTH
 from dbslice.core.graph import GraphTraverser, TraversalConfig, TraversalResult
 from dbslice.exceptions import (
+    ExtractionError,
     NoRowsFoundError,
     TableNotFoundError,
 )
@@ -635,6 +636,11 @@ class ExtractionEngine:
         table_info = self.schema.get_table(seed.table)
         assert table_info is not None  # Guaranteed by has_table check above
         pk_columns = table_info.primary_key
+        if not pk_columns:
+            raise ExtractionError(
+                "Seed table has no primary key; choose a seed table with a primary key",
+                table=seed.table,
+            )
 
         where_clause, params = seed.to_where_clause()
         seed_rows = list(self.adapter.fetch_rows(seed.table, where_clause, params))

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -819,6 +819,101 @@ class TestCLIInspect:
         assert "user_id" in combined  # FK column
 
 
+class TestCLIEnvironmentFallback:
+    """Test DATABASE_URL fallback behavior for commands."""
+
+    def test_cli_extract_uses_database_url_env(self, ecommerce_schema: dict, test_db_url: str):
+        env = os.environ.copy()
+        env["DATABASE_URL"] = test_db_url
+
+        result = subprocess.run(
+            [
+                "python",
+                "-m",
+                "dbslice.cli",
+                "extract",
+                "--seed",
+                "orders.id=1",
+                "--no-progress",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0
+        assert "INSERT INTO" in result.stdout
+
+    def test_cli_init_uses_database_url_env(self, ecommerce_schema: dict, test_db_url: str):
+        env = os.environ.copy()
+        env["DATABASE_URL"] = test_db_url
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as cfg:
+            cfg_path = cfg.name
+
+        try:
+            result = subprocess.run(
+                [
+                    "python",
+                    "-m",
+                    "dbslice.cli",
+                    "init",
+                    "--out-file",
+                    cfg_path,
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            assert result.returncode == 0
+            assert os.path.exists(cfg_path)
+            with open(cfg_path, encoding="utf-8") as f:
+                assert "database:" in f.read()
+        finally:
+            if os.path.exists(cfg_path):
+                os.unlink(cfg_path)
+
+    def test_cli_inspect_uses_database_url_env(self, ecommerce_schema: dict, test_db_url: str):
+        env = os.environ.copy()
+        env["DATABASE_URL"] = test_db_url
+
+        result = subprocess.run(
+            [
+                "python",
+                "-m",
+                "dbslice.cli",
+                "inspect",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        assert "users" in combined
+
+    def test_cli_inspect_without_url_or_env_fails(self):
+        env = os.environ.copy()
+        env.pop("DATABASE_URL", None)
+
+        result = subprocess.run(
+            [
+                "python",
+                "-m",
+                "dbslice.cli",
+                "inspect",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert "Database URL is required" in combined
+
+
 class TestCLIVersion:
     """Test version flag."""
 

--- a/tests/integration/test_pkless_safety.py
+++ b/tests/integration/test_pkless_safety.py
@@ -1,0 +1,113 @@
+"""Integration tests for PK-less table safety hardening."""
+
+import json
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_seed_table_without_primary_key_fails(
+    pg_connection,
+    clean_database,
+    test_db_url: str,
+):
+    with pg_connection.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE audit_log (
+                event_id INTEGER NOT NULL,
+                message TEXT
+            )
+            """
+        )
+        cur.execute(
+            """
+            INSERT INTO audit_log (event_id, message) VALUES
+            (1, 'login'),
+            (2, 'logout')
+            """
+        )
+
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "dbslice.cli",
+            "extract",
+            test_db_url,
+            "--seed",
+            "audit_log.event_id=1",
+            "--no-progress",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "Seed table has no primary key" in combined
+
+
+def test_non_seed_pk_less_table_is_skipped_safely(
+    pg_connection,
+    clean_database,
+    test_db_url: str,
+):
+    with pg_connection.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE parent_lookup (
+                code TEXT NOT NULL UNIQUE,
+                label TEXT
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE child_events (
+                id SERIAL PRIMARY KEY,
+                parent_code TEXT REFERENCES parent_lookup(code),
+                payload TEXT
+            )
+            """
+        )
+        cur.execute(
+            """
+            INSERT INTO parent_lookup (code, label) VALUES
+            ('A', 'Alpha'),
+            ('B', 'Beta')
+            """
+        )
+        cur.execute(
+            """
+            INSERT INTO child_events (id, parent_code, payload) VALUES
+            (1, 'A', 'first'),
+            (2, 'B', 'second')
+            """
+        )
+
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "dbslice.cli",
+            "extract",
+            test_db_url,
+            "--seed",
+            "child_events.id=1",
+            "--output",
+            "json",
+            "--no-validate",
+            "--no-progress",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    tables = payload["tables"]
+    assert "child_events" in tables
+    assert "parent_lookup" not in tables

--- a/tests/integration/test_pkless_safety.py
+++ b/tests/integration/test_pkless_safety.py
@@ -110,4 +110,6 @@ def test_non_seed_pk_less_table_is_skipped_safely(
     payload = json.loads(result.stdout)
     tables = payload["tables"]
     assert "child_events" in tables
-    assert "parent_lookup" not in tables
+    # PK-less parent table should be skipped for data extraction. Depending on
+    # output formatter behavior, it may be omitted or included as an empty list.
+    assert tables.get("parent_lookup", []) == []

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -1,0 +1,120 @@
+"""Tests for CLI environment-variable precedence and parsing."""
+
+from pathlib import Path
+
+import pytest
+import typer
+
+import dbslice.cli as cli
+from dbslice.config import OutputFormat, TraversalDirection
+
+
+@pytest.fixture
+def capture_extract(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_execute(config, _console):
+        captured["extract_config"] = config
+        return object(), object(), object()
+
+    def fake_handle_output(**kwargs):
+        captured["output_format"] = kwargs["output_format"]
+
+    monkeypatch.setattr(cli, "_execute_extraction", fake_execute)
+    monkeypatch.setattr(cli, "_handle_output_format", fake_handle_output)
+
+    return captured
+
+
+def test_extract_uses_database_url_from_env(monkeypatch, capture_extract):
+    env_url = "postgresql://env_user:env_pass@localhost:5432/envdb"
+    monkeypatch.setenv("DATABASE_URL", env_url)
+
+    cli.extract(
+        seed=["users.id=1"],
+        no_progress=True,
+    )
+
+    extract_config = capture_extract["extract_config"]
+    assert extract_config.database_url == env_url
+
+
+def test_extract_cli_flags_override_env(monkeypatch, capture_extract):
+    monkeypatch.setenv("DBSLICE_DEPTH", "9")
+    monkeypatch.setenv("DBSLICE_DIRECTION", "down")
+    monkeypatch.setenv("DBSLICE_OUTPUT_FORMAT", "json")
+    monkeypatch.setenv("DBSLICE_ANONYMIZE", "false")
+    monkeypatch.setenv("DBSLICE_REDACT_FIELDS", "users.email,users.phone")
+
+    cli.extract(
+        database_url="postgresql://cli_user:cli_pass@localhost:5432/clidb",
+        seed=["users.id=1"],
+        depth=2,
+        direction="up",
+        output="sql",
+        anonymize=True,
+        redact=["users.custom_field"],
+        no_progress=True,
+    )
+
+    extract_config = capture_extract["extract_config"]
+    assert extract_config.depth == 2
+    assert extract_config.direction == TraversalDirection.UP
+    assert extract_config.output_format == OutputFormat.SQL
+    assert extract_config.anonymize is True
+    assert extract_config.redact_fields == ["users.custom_field"]
+
+
+def test_extract_env_overrides_config_when_cli_missing(monkeypatch, tmp_path, capture_extract):
+    config_path = tmp_path / "dbslice.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "database:",
+                "  url: postgresql://config_user:config_pass@localhost:5432/configdb",
+                "extraction:",
+                "  default_depth: 7",
+                "  direction: down",
+                "anonymization:",
+                "  enabled: false",
+                "output:",
+                "  format: sql",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://env_user:env_pass@localhost:5432/envdb")
+    monkeypatch.setenv("DBSLICE_DEPTH", "4")
+    monkeypatch.setenv("DBSLICE_DIRECTION", "up")
+    monkeypatch.setenv("DBSLICE_OUTPUT_FORMAT", "json")
+    monkeypatch.setenv("DBSLICE_ANONYMIZE", "true")
+    monkeypatch.setenv("DBSLICE_REDACT_FIELDS", "users.ssn,users.passport")
+
+    cli.extract(
+        config=Path(config_path),
+        seed=["users.id=1"],
+        no_progress=True,
+    )
+
+    extract_config = capture_extract["extract_config"]
+    assert extract_config.database_url == "postgresql://env_user:env_pass@localhost:5432/envdb"
+    assert extract_config.depth == 4
+    assert extract_config.direction == TraversalDirection.UP
+    assert extract_config.output_format == OutputFormat.JSON
+    assert extract_config.anonymize is True
+    assert extract_config.redact_fields == ["users.ssn", "users.passport"]
+
+
+def test_extract_invalid_env_value_fails_fast(monkeypatch, capsys):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://env_user:env_pass@localhost:5432/envdb")
+    monkeypatch.setenv("DBSLICE_DIRECTION", "sideways")
+
+    with pytest.raises(typer.Exit) as exc_info:
+        cli.extract(seed=["users.id=1"], no_progress=True)
+
+    assert exc_info.value.exit_code == 1
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Validation Error" in combined
+    assert "DBSLICE_DIRECTION" in combined

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -216,6 +216,87 @@ extraction:
         finally:
             Path(temp_path).unlink()
 
+    def test_from_yaml_database_url_env_placeholder(self, monkeypatch):
+        monkeypatch.setenv(
+            "TEST_DATABASE_URL",
+            "postgresql://placeholder:placeholder@localhost:5432/example",
+        )
+        yaml_content = """
+database:
+  url: ${TEST_DATABASE_URL}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            config = DbsliceConfig.from_yaml(temp_path)
+            assert config.database.url == "postgresql://placeholder:placeholder@localhost:5432/example"
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_database_url_file_placeholder(self, monkeypatch, tmp_path):
+        url_file = tmp_path / "db_url.txt"
+        url_file.write_text("postgresql://file:user@localhost:5432/from_file\n", encoding="utf-8")
+        monkeypatch.setenv("TEST_DATABASE_URL_FILE", str(url_file))
+
+        yaml_content = """
+database:
+  url: ${TEST_DATABASE_URL_FILE}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            config = DbsliceConfig.from_yaml(temp_path)
+            assert config.database.url == "postgresql://file:user@localhost:5432/from_file"
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_database_url_missing_env_var(self, monkeypatch):
+        missing_key = "DBSLICE_TEST_MISSING_DATABASE_URL"
+        monkeypatch.delenv(missing_key, raising=False)
+
+        yaml_content = """
+database:
+  url: ${DBSLICE_TEST_MISSING_DATABASE_URL}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ConfigFileError) as exc_info:
+                DbsliceConfig.from_yaml(temp_path)
+            assert missing_key in str(exc_info.value)
+        finally:
+            Path(temp_path).unlink()
+
+    def test_from_yaml_database_url_file_placeholder_unreadable(self, monkeypatch, tmp_path):
+        missing_file = tmp_path / "missing_db_url.txt"
+        monkeypatch.setenv("TEST_DATABASE_URL_FILE", str(missing_file))
+
+        yaml_content = """
+database:
+  url: ${TEST_DATABASE_URL_FILE}
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ConfigFileError) as exc_info:
+                DbsliceConfig.from_yaml(temp_path)
+            assert "TEST_DATABASE_URL_FILE" in str(exc_info.value)
+            assert str(missing_file) in str(exc_info.value)
+        finally:
+            Path(temp_path).unlink()
+
     def test_from_yaml_full_config(self):
         yaml_content = """
 database:

--- a/tests/test_pkless_safety.py
+++ b/tests/test_pkless_safety.py
@@ -1,0 +1,112 @@
+"""Safety tests for tables without primary keys."""
+
+import pytest
+
+from dbslice.adapters.postgresql import PostgreSQLAdapter
+from dbslice.config import ExtractConfig, SeedSpec
+from dbslice.core.engine import ExtractionEngine
+from dbslice.exceptions import ExtractionError
+from dbslice.models import Column, ForeignKey, SchemaGraph, Table
+from tests.conftest import MockAdapter
+
+
+class _NoCursorConnection:
+    """Connection stub that fails if SQL execution is attempted."""
+
+    def cursor(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("cursor() should not be called for PK-less guarded paths")
+
+
+def test_seed_table_without_primary_key_fails_fast():
+    schema = SchemaGraph(
+        tables={
+            "events": Table(
+                name="events",
+                schema="public",
+                columns=[
+                    Column(name="id", data_type="INTEGER", nullable=False, is_primary_key=False),
+                    Column(
+                        name="payload",
+                        data_type="TEXT",
+                        nullable=True,
+                        is_primary_key=False,
+                    ),
+                ],
+                primary_key=(),
+                foreign_keys=[],
+            )
+        },
+        edges=[],
+    )
+    adapter = MockAdapter(schema, {"events": [{"id": 1, "payload": "x"}]})
+    config = ExtractConfig(
+        database_url="postgresql://localhost/test",
+        seeds=[SeedSpec.parse("events.id=1")],
+        validate=False,
+    )
+
+    engine = ExtractionEngine(config)
+    engine.schema = schema
+    engine.adapter = adapter
+
+    with pytest.raises(ExtractionError, match="Seed table has no primary key"):
+        engine._process_seed(config.seeds[0])
+
+
+def test_fetch_by_pk_returns_no_rows_when_pk_columns_empty():
+    adapter = PostgreSQLAdapter()
+    adapter._conn = _NoCursorConnection()
+
+    rows = list(adapter.fetch_by_pk("events", (), {(1,)}))
+    assert rows == []
+
+
+def test_fetch_by_pk_chunked_returns_no_chunks_when_pk_columns_empty():
+    adapter = PostgreSQLAdapter()
+    adapter._conn = _NoCursorConnection()
+
+    chunks = list(adapter.fetch_by_pk_chunked("events", (), {(1,)}, chunk_size=100))
+    assert chunks == []
+
+
+def test_fetch_fk_values_returns_empty_when_source_table_has_no_pk():
+    adapter = PostgreSQLAdapter()
+    adapter._conn = _NoCursorConnection()
+
+    schema = SchemaGraph(
+        tables={
+            "events": Table(
+                name="events",
+                schema="public",
+                columns=[
+                    Column(name="event_id", data_type="INTEGER", nullable=False, is_primary_key=False),
+                    Column(name="user_id", data_type="INTEGER", nullable=False, is_primary_key=False),
+                ],
+                primary_key=(),
+                foreign_keys=[],
+            ),
+            "users": Table(
+                name="users",
+                schema="public",
+                columns=[
+                    Column(name="id", data_type="INTEGER", nullable=False, is_primary_key=True),
+                ],
+                primary_key=("id",),
+                foreign_keys=[],
+            ),
+        },
+        edges=[],
+    )
+    adapter.get_schema = lambda schema_name=None: schema  # type: ignore[method-assign]
+
+    fk = ForeignKey(
+        name="fk_events_users",
+        source_table="events",
+        source_columns=("user_id",),
+        target_table="users",
+        target_columns=("id",),
+        is_nullable=False,
+    )
+
+    result = adapter.fetch_fk_values("events", fk, {(1,)})
+    assert result == set()


### PR DESCRIPTION
- Support `database.url` placeholders `${VAR}` and `${VAR_FILE}` in YAML config
- Fail fast for missing env vars and unreadable `_FILE` targets
- Add extract env defaults:
  - `DATABASE_URL`
  - `DBSLICE_DEPTH`
  - `DBSLICE_DIRECTION`
  - `DBSLICE_OUTPUT_FORMAT`
  - `DBSLICE_ANONYMIZE`
  - `DBSLICE_REDACT_FIELDS`
- Enforce precedence: `CLI > Env > Config`
- Allow `init` and `inspect` to fallback to `DATABASE_URL` when URL arg is omitted
- Harden PK-less behavior:
  - error on PK-less seed tables
  - skip non-seed PK-less PK/FK fetch paths safely with warnings
- Update docs for placeholder semantics, env formats, and precedence
- Add unit/integration coverage for env resolution/fallback and PK-less safety